### PR TITLE
Configure Biome linter/formatter based on ksugawara61/curio settings

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,79 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on",
+        "useSortedKeys": {
+          "level": "on",
+          "options": {
+            "sortOrder": "natural"
+          }
+        }
+      }
+    }
+  },
+  "files": {
+    "includes": [
+      "biome.jsonc",
+      "package.json",
+      "**/*.ts",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/coverage",
+      "!**/pnpm-lock.yaml"
+    ]
+  },
+  "formatter": {
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 10
+          }
+        },
+        "noUselessTernary": "error",
+        "useArrowFunction": "error"
+      },
+      "correctness": {
+        "noUnusedVariables": "error"
+      },
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noNestedPromises": "error"
+      },
+      "performance": {
+        "noBarrelFile": "off"
+      },
+      "recommended": true,
+      "style": {
+        "noDefaultExport": "error",
+        "noInferrableTypes": "error",
+        "noNonNullAssertion": "error",
+        "noParameterAssign": "error",
+        "noUnusedTemplateLiteral": "error",
+        "noUselessElse": "error",
+        "useAsConstAssertion": "error",
+        "useConsistentTypeDefinitions": {
+          "level": "error",
+          "options": {
+            "style": "type"
+          }
+        },
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useFilenamingConvention": "off",
+        "useNumberNamespace": "error",
+        "useSingleVarDeclarator": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      }
+    }
+  }
+}

--- a/cli.ts
+++ b/cli.ts
@@ -1,8 +1,64 @@
 #!/usr/bin/env node
-import { Command } from "commander";
-import { getDiffFiles, runCoverage, formatResult } from "./core.js";
-import { detectRunner } from "./runner/detect.js";
 import { resolve } from "node:path";
+import { Command } from "commander";
+import { formatResult, getDiffFiles, runCoverage } from "./core.js";
+import { detectRunner, type RunnerType } from "./runner/detect.js";
+
+type MeasureOpts = {
+  base: string;
+  cmd?: string;
+  diffOnly: boolean;
+  json: boolean;
+  threshold?: number;
+};
+
+async function measureFiles(
+  opts: MeasureOpts,
+  cwd: string,
+  extensions: string[],
+  runner: RunnerType,
+): Promise<void> {
+  const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
+
+  if (diffFiles.length === 0) {
+    console.log("No changed source files found.");
+    process.exit(0);
+  }
+
+  console.error(`📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`);
+
+  if (opts.diffOnly) {
+    console.log(diffFiles.map((f) => f.path).join("\n"));
+    process.exit(0);
+  }
+
+  const runnerLabel = runner === "vitest" ? "Vitest" : "Jest";
+  console.error(`🧪 Running ${runnerLabel}...\n`);
+
+  const result = await runCoverage(
+    {
+      base: opts.base,
+      cwd,
+      extensions,
+      runner,
+      testCommand: opts.cmd,
+    },
+    diffFiles,
+  );
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatResult(result, opts.threshold));
+  }
+
+  if (
+    opts.threshold !== undefined &&
+    result.summary.lines.pct < opts.threshold
+  ) {
+    process.exit(1);
+  }
+}
 
 const program = new Command();
 
@@ -19,61 +75,44 @@ program
   .option(
     "-r, --runner <runner>",
     "Test runner: jest | vitest | auto (default: auto)",
-    "auto"
+    "auto",
   )
   .option("--cmd <command>", "Override test command (e.g. 'pnpm vitest')")
-  .option("--ext <extensions>", "Comma-separated file extensions", "ts,tsx,js,jsx")
-  .option("--threshold <number>", "Fail if line coverage is below this %", parseFloat)
+  .option(
+    "--ext <extensions>",
+    "Comma-separated file extensions",
+    "ts,tsx,js,jsx",
+  )
+  .option(
+    "--threshold <number>",
+    "Fail if line coverage is below this %",
+    Number.parseFloat,
+  )
   .option("--json", "Output raw JSON")
   .option("--diff-only", "Only show diff files, don't run tests")
   .action(async (opts) => {
     const cwd = resolve(opts.cwd);
     const extensions = opts.ext.split(",").map((e: string) => e.trim());
-
-    // Resolve runner early so we can show it in the header
     const runner =
       opts.runner === "auto" ? await detectRunner(cwd) : opts.runner;
 
-    console.error(`📊 Measuring diff coverage against ${opts.base} (runner: ${runner})...`);
+    console.error(
+      `📊 Measuring diff coverage against ${opts.base} (runner: ${runner})...`,
+    );
 
     try {
-      const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
-
-      if (diffFiles.length === 0) {
-        console.log("No changed source files found.");
-        process.exit(0);
-      }
-
-      console.error(`📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`);
-
-      if (opts.diffOnly) {
-        console.log(diffFiles.map((f) => f.path).join("\n"));
-        process.exit(0);
-      }
-
-      const runnerLabel = runner === "vitest" ? "Vitest" : "Jest";
-      console.error(`🧪 Running ${runnerLabel}...\n`);
-
-      const result = await runCoverage(
+      await measureFiles(
         {
-          cwd,
           base: opts.base,
-          runner,
-          testCommand: opts.cmd,
-          extensions,
+          cmd: opts.cmd,
+          diffOnly: opts.diffOnly,
+          json: opts.json,
+          threshold: opts.threshold,
         },
-        diffFiles
+        cwd,
+        extensions,
+        runner,
       );
-
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(formatResult(result, opts.threshold));
-      }
-
-      if (opts.threshold !== undefined && result.summary.lines.pct < opts.threshold) {
-        process.exit(1);
-      }
     } catch (err) {
       console.error("Error:", err instanceof Error ? err.message : err);
       process.exit(1);
@@ -85,7 +124,11 @@ program
   .description("List changed source files without running tests")
   .option("-b, --base <branch>", "Base branch to diff against", "main")
   .option("-c, --cwd <path>", "Project root directory", process.cwd())
-  .option("--ext <extensions>", "Comma-separated file extensions", "ts,tsx,js,jsx")
+  .option(
+    "--ext <extensions>",
+    "Comma-separated file extensions",
+    "ts,tsx,js,jsx",
+  )
   .action(async (opts) => {
     const cwd = resolve(opts.cwd);
     const extensions = opts.ext.split(",").map((e: string) => e.trim());

--- a/core.ts
+++ b/core.ts
@@ -1,50 +1,82 @@
-import { execa } from "execa";
 import { readFile } from "node:fs/promises";
-import { resolve, relative } from "node:path";
+import { relative, resolve } from "node:path";
+import { execa } from "execa";
 import { detectRunner, type RunnerType } from "./runner/detect.js";
 import { runJest } from "./runner/jest.js";
 import { runVitest } from "./runner/vitest.js";
 
-export interface DiffFile {
-  path: string;
+export type DiffFile = {
+  addedLines: number[];
   additions: number;
   deletions: number;
-  addedLines: number[];
-}
-
-export interface FileCoverage {
   path: string;
-  statements: { total: number; covered: number; pct: number };
-  branches: { total: number; covered: number; pct: number };
-  functions: { total: number; covered: number; pct: number };
-  lines: { total: number; covered: number; pct: number };
-  uncoveredLines: number[];
-}
+};
 
-export interface DiffCoverageResult {
+export type FileCoverage = {
+  branches: { covered: number; pct: number; total: number };
+  functions: { covered: number; pct: number; total: number };
+  lines: { covered: number; pct: number; total: number };
+  path: string;
+  statements: { covered: number; pct: number; total: number };
+  uncoveredLines: number[];
+};
+
+export type DiffCoverageResult = {
+  files: FileCoverage[];
   runner: RunnerType;
   summary: {
-    totalFiles: number;
+    branches: { covered: number; pct: number; total: number };
     coveredFiles: number;
-    statements: { total: number; covered: number; pct: number };
-    lines: { total: number; covered: number; pct: number };
-    functions: { total: number; covered: number; pct: number };
-    branches: { total: number; covered: number; pct: number };
+    functions: { covered: number; pct: number; total: number };
+    lines: { covered: number; pct: number; total: number };
+    statements: { covered: number; pct: number; total: number };
+    totalFiles: number;
   };
-  files: FileCoverage[];
-  uncoveredFiles: string[];
   timestamp: string;
-}
+  uncoveredFiles: string[];
+};
 
-export interface RunOptions {
-  cwd: string;
+export type RunOptions = {
   base?: string;
+  cwd: string;
+  excludePatterns?: string[];
+  extensions?: string[];
   runner?: RunnerType | "auto";
   testCommand?: string;
-  extensions?: string[];
-  excludePatterns?: string[];
   threshold?: number;
-}
+};
+
+// Istanbul/V8 coverage file format
+type StatementLocation = { start?: { line?: number } };
+export type FileDetail = {
+  b?: Record<string, number[]>;
+  branchMap?: Record<string, { locations?: StatementLocation[] }>;
+  f?: Record<string, number>;
+  fnMap?: Record<string, { loc?: StatementLocation; name?: string }>;
+  s?: Record<string, number>;
+  statementMap?: Record<string, StatementLocation>;
+};
+type CoverageDetail = Record<string, FileDetail | undefined>;
+
+type CoverageMetric = { covered: number; pct: number; total: number };
+type CoverageSummaryEntry = {
+  branches: CoverageMetric;
+  functions: CoverageMetric;
+  lines: CoverageMetric;
+  statements: CoverageMetric;
+};
+type CoverageSummary = Record<string, CoverageSummaryEntry>;
+
+type Totals = {
+  branchCovered: number;
+  branchTotal: number;
+  fnCovered: number;
+  fnTotal: number;
+  lineCovered: number;
+  lineTotal: number;
+  stmtCovered: number;
+  stmtTotal: number;
+};
 
 const DEFAULT_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mts", "cts"];
 const DEFAULT_EXCLUDE = [
@@ -63,7 +95,7 @@ export async function getDiffFiles(
   cwd: string,
   base = "main",
   extensions = DEFAULT_EXTENSIONS,
-  excludePatterns = DEFAULT_EXCLUDE
+  excludePatterns = DEFAULT_EXCLUDE,
 ): Promise<DiffFile[]> {
   const extPattern = extensions.join("|");
 
@@ -78,7 +110,7 @@ export async function getDiffFiles(
   const { stdout: nameOnly } = await execa(
     "git",
     ["diff", baseRef, "--name-only", "--diff-filter=ACM"],
-    { cwd }
+    { cwd },
   );
 
   const allFiles = nameOnly
@@ -92,15 +124,15 @@ export async function getDiffFiles(
   const { stdout: diffStat } = await execa(
     "git",
     ["diff", baseRef, "--numstat", "--diff-filter=ACM"],
-    { cwd }
+    { cwd },
   );
 
   const statMap = new Map<string, { additions: number; deletions: number }>();
   for (const line of diffStat.split("\n").filter(Boolean)) {
     const [add, del, file] = line.split("\t");
     statMap.set(file, {
-      additions: parseInt(add) || 0,
-      deletions: parseInt(del) || 0,
+      additions: Number.parseInt(add, 10) || 0,
+      deletions: Number.parseInt(del, 10) || 0,
     });
   }
 
@@ -108,7 +140,7 @@ export async function getDiffFiles(
   for (const filePath of allFiles) {
     const stat = statMap.get(filePath) ?? { additions: 0, deletions: 0 };
     const addedLines = await getAddedLines(cwd, baseRef, filePath);
-    files.push({ path: filePath, ...stat, addedLines });
+    files.push({ addedLines, path: filePath, ...stat });
   }
 
   return files;
@@ -117,13 +149,13 @@ export async function getDiffFiles(
 async function getAddedLines(
   cwd: string,
   base: string,
-  filePath: string
+  filePath: string,
 ): Promise<number[]> {
   try {
     const { stdout } = await execa(
       "git",
       ["diff", base, "--unified=0", "--", filePath],
-      { cwd }
+      { cwd },
     );
 
     const lines: number[] = [];
@@ -132,7 +164,7 @@ async function getAddedLines(
     for (const line of stdout.split("\n")) {
       const hunkHeader = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
       if (hunkHeader) {
-        currentLine = parseInt(hunkHeader[1]);
+        currentLine = Number.parseInt(hunkHeader[1], 10);
         continue;
       }
       if (line.startsWith("+") && !line.startsWith("+++")) {
@@ -152,7 +184,7 @@ async function getAddedLines(
 
 export async function runCoverage(
   options: RunOptions,
-  diffFiles: DiffFile[]
+  diffFiles: DiffFile[],
 ): Promise<DiffCoverageResult> {
   const { cwd } = options;
 
@@ -183,113 +215,158 @@ export const runJestCoverage = runCoverage;
 
 // ─── Report parsing ───────────────────────────────────────────────────────────
 
-async function parseCoverageReport(
-  cwd: string,
+function addMissingDiffFiles(
+  files: FileCoverage[],
+  uncoveredFiles: string[],
   diffFiles: DiffFile[],
-  runner: RunnerType
-): Promise<DiffCoverageResult> {
-  const summaryPath = resolve(cwd, "coverage/coverage-summary.json");
-  const detailPath = resolve(cwd, "coverage/coverage-final.json");
-
-  let summaryData: Record<string, any> = {};
-  let detailData: Record<string, any> = {};
-
-  try {
-    summaryData = JSON.parse(await readFile(summaryPath, "utf-8"));
-  } catch {
-    return emptyResult(runner, "Coverage report not found. Check that coverage is enabled in your config.");
-  }
-
-  try {
-    detailData = JSON.parse(await readFile(detailPath, "utf-8"));
-  } catch {
-    // detail report is optional
-  }
-
-  const diffPaths = new Set(diffFiles.map((f) => resolve(cwd, f.path)));
-  const files: FileCoverage[] = [];
-  const uncoveredFiles: string[] = [];
-
-  const totals = {
-    stmtTotal: 0, stmtCovered: 0,
-    lineTotal: 0, lineCovered: 0,
-    fnTotal: 0, fnCovered: 0,
-    branchTotal: 0, branchCovered: 0,
-  };
-
-  for (const [absPath, data] of Object.entries(summaryData)) {
-    if (absPath === "total") continue;
-
-    const relPath = relative(cwd, absPath);
-    if (!diffPaths.has(absPath) && !diffPaths.has(resolve(cwd, relPath))) {
-      continue;
-    }
-
-    const s = data.statements;
-    const l = data.lines;
-    const f = data.functions;
-    const b = data.branches;
-
-    totals.stmtTotal += s.total;   totals.stmtCovered += s.covered;
-    totals.lineTotal += l.total;   totals.lineCovered += l.covered;
-    totals.fnTotal += f.total;     totals.fnCovered += f.covered;
-    totals.branchTotal += b.total; totals.branchCovered += b.covered;
-
-    const uncoveredLines = getUncoveredLines(detailData[absPath]);
-
-    files.push({
-      path: relPath,
-      statements: { total: s.total, covered: s.covered, pct: s.pct },
-      branches:   { total: b.total, covered: b.covered, pct: b.pct },
-      functions:  { total: f.total, covered: f.covered, pct: f.pct },
-      lines:      { total: l.total, covered: l.covered, pct: l.pct },
-      uncoveredLines,
-    });
-
-    if (l.pct < 50) uncoveredFiles.push(relPath);
-  }
-
-  // Files in diff but absent from coverage report = 0% covered
+  cwd: string,
+): void {
   for (const df of diffFiles) {
     const abs = resolve(cwd, df.path);
     const inCoverage = files.some((f) => resolve(cwd, f.path) === abs);
     if (!inCoverage) {
       uncoveredFiles.push(df.path);
       files.push({
+        branches: { covered: 0, pct: 0, total: 0 },
+        functions: { covered: 0, pct: 0, total: 0 },
+        lines: { covered: 0, pct: 0, total: 0 },
         path: df.path,
-        statements: { total: 0, covered: 0, pct: 0 },
-        branches:   { total: 0, covered: 0, pct: 0 },
-        functions:  { total: 0, covered: 0, pct: 0 },
-        lines:      { total: 0, covered: 0, pct: 0 },
+        statements: { covered: 0, pct: 0, total: 0 },
         uncoveredLines: [],
       });
     }
   }
+}
+
+function computeFileCoverages(
+  summaryData: CoverageSummary,
+  detailData: CoverageDetail,
+  cwd: string,
+  diffFiles: DiffFile[],
+): { files: FileCoverage[]; totals: Totals; uncoveredFiles: string[] } {
+  const diffPaths = new Set(diffFiles.map((f) => resolve(cwd, f.path)));
+  const files: FileCoverage[] = [];
+  const uncoveredFiles: string[] = [];
+  const totals: Totals = {
+    branchCovered: 0,
+    branchTotal: 0,
+    fnCovered: 0,
+    fnTotal: 0,
+    lineCovered: 0,
+    lineTotal: 0,
+    stmtCovered: 0,
+    stmtTotal: 0,
+  };
+
+  for (const [absPath, data] of Object.entries(summaryData)) {
+    if (absPath === "total") continue;
+    const relPath = relative(cwd, absPath);
+    if (!diffPaths.has(absPath) && !diffPaths.has(resolve(cwd, relPath)))
+      continue;
+
+    const { branches: b, functions: f, lines: l, statements: s } = data;
+    totals.stmtTotal += s.total;
+    totals.stmtCovered += s.covered;
+    totals.lineTotal += l.total;
+    totals.lineCovered += l.covered;
+    totals.fnTotal += f.total;
+    totals.fnCovered += f.covered;
+    totals.branchTotal += b.total;
+    totals.branchCovered += b.covered;
+
+    const uncoveredLines = getUncoveredLines(detailData[absPath]);
+    files.push({
+      branches: { covered: b.covered, pct: b.pct, total: b.total },
+      functions: { covered: f.covered, pct: f.pct, total: f.total },
+      lines: { covered: l.covered, pct: l.pct, total: l.total },
+      path: relPath,
+      statements: { covered: s.covered, pct: s.pct, total: s.total },
+      uncoveredLines,
+    });
+    if (l.pct < 50) uncoveredFiles.push(relPath);
+  }
+
+  addMissingDiffFiles(files, uncoveredFiles, diffFiles, cwd);
+  return { files, totals, uncoveredFiles };
+}
+
+async function parseCoverageReport(
+  cwd: string,
+  diffFiles: DiffFile[],
+  runner: RunnerType,
+): Promise<DiffCoverageResult> {
+  const summaryPath = resolve(cwd, "coverage/coverage-summary.json");
+  const detailPath = resolve(cwd, "coverage/coverage-final.json");
+
+  let summaryData: CoverageSummary = {};
+  let detailData: CoverageDetail = {};
+
+  try {
+    summaryData = JSON.parse(
+      await readFile(summaryPath, "utf-8"),
+    ) as CoverageSummary;
+  } catch {
+    return emptyResult(
+      runner,
+      "Coverage report not found. Check that coverage is enabled in your config.",
+    );
+  }
+
+  try {
+    detailData = JSON.parse(
+      await readFile(detailPath, "utf-8"),
+    ) as CoverageDetail;
+  } catch {
+    // detail report is optional
+  }
+
+  const { files, uncoveredFiles, totals } = computeFileCoverages(
+    summaryData,
+    detailData,
+    cwd,
+    diffFiles,
+  );
 
   const pct = (covered: number, total: number) =>
     total === 0 ? 0 : Math.round((covered / total) * 10000) / 100;
 
   return {
+    files,
     runner,
     summary: {
-      totalFiles: files.length,
+      branches: {
+        covered: totals.branchCovered,
+        pct: pct(totals.branchCovered, totals.branchTotal),
+        total: totals.branchTotal,
+      },
       coveredFiles: files.filter((f) => f.lines.pct > 0).length,
-      statements: { total: totals.stmtTotal, covered: totals.stmtCovered, pct: pct(totals.stmtCovered, totals.stmtTotal) },
-      lines:      { total: totals.lineTotal, covered: totals.lineCovered, pct: pct(totals.lineCovered, totals.lineTotal) },
-      functions:  { total: totals.fnTotal,   covered: totals.fnCovered,   pct: pct(totals.fnCovered, totals.fnTotal) },
-      branches:   { total: totals.branchTotal, covered: totals.branchCovered, pct: pct(totals.branchCovered, totals.branchTotal) },
+      functions: {
+        covered: totals.fnCovered,
+        pct: pct(totals.fnCovered, totals.fnTotal),
+        total: totals.fnTotal,
+      },
+      lines: {
+        covered: totals.lineCovered,
+        pct: pct(totals.lineCovered, totals.lineTotal),
+        total: totals.lineTotal,
+      },
+      statements: {
+        covered: totals.stmtCovered,
+        pct: pct(totals.stmtCovered, totals.stmtTotal),
+        total: totals.stmtTotal,
+      },
+      totalFiles: files.length,
     },
-    files,
-    uncoveredFiles,
     timestamp: new Date().toISOString(),
+    uncoveredFiles,
   };
 }
 
-function getUncoveredLines(fileDetail: any): number[] {
+function getUncoveredLines(fileDetail: FileDetail | undefined): number[] {
   if (!fileDetail?.s) return [];
   const lines: Set<number> = new Set();
   for (const [id, count] of Object.entries(fileDetail.s)) {
-    if ((count as number) === 0) {
+    if (count === 0) {
       const loc = fileDetail.statementMap?.[id]?.start?.line;
       if (loc) lines.add(loc);
     }
@@ -297,27 +374,39 @@ function getUncoveredLines(fileDetail: any): number[] {
   return [...lines].sort((a, b) => a - b);
 }
 
-function emptyResult(runner: RunnerType, _message?: string): DiffCoverageResult {
+function emptyResult(
+  runner: RunnerType,
+  _message?: string,
+): DiffCoverageResult {
   return {
+    files: [],
     runner,
     summary: {
-      totalFiles: 0,
+      branches: { covered: 0, pct: 0, total: 0 },
       coveredFiles: 0,
-      statements: { total: 0, covered: 0, pct: 0 },
-      lines:      { total: 0, covered: 0, pct: 0 },
-      functions:  { total: 0, covered: 0, pct: 0 },
-      branches:   { total: 0, covered: 0, pct: 0 },
+      functions: { covered: 0, pct: 0, total: 0 },
+      lines: { covered: 0, pct: 0, total: 0 },
+      statements: { covered: 0, pct: 0, total: 0 },
+      totalFiles: 0,
     },
-    files: [],
-    uncoveredFiles: [],
     timestamp: new Date().toISOString(),
+    uncoveredFiles: [],
   };
 }
 
 // ─── Formatter ────────────────────────────────────────────────────────────────
 
-export function formatResult(result: DiffCoverageResult, threshold?: number): string {
-  const { runner, summary, files } = result;
+function getCoverageIcon(pct: number): string {
+  if (pct >= 80) return "✅";
+  if (pct >= 50) return "⚠️";
+  return "❌";
+}
+
+export function formatResult(
+  result: DiffCoverageResult,
+  threshold?: number,
+): string {
+  const { files, runner, summary } = result;
   const out: string[] = [];
 
   out.push(`=== Diff Coverage Report (${runner}) ===\n`);
@@ -328,10 +417,18 @@ export function formatResult(result: DiffCoverageResult, threshold?: number): st
   }
 
   out.push(`Files changed: ${summary.totalFiles}`);
-  out.push(`Lines:      ${summary.lines.pct}% (${summary.lines.covered}/${summary.lines.total})`);
-  out.push(`Statements: ${summary.statements.pct}% (${summary.statements.covered}/${summary.statements.total})`);
-  out.push(`Functions:  ${summary.functions.pct}% (${summary.functions.covered}/${summary.functions.total})`);
-  out.push(`Branches:   ${summary.branches.pct}% (${summary.branches.covered}/${summary.branches.total})`);
+  out.push(
+    `Lines:      ${summary.lines.pct}% (${summary.lines.covered}/${summary.lines.total})`,
+  );
+  out.push(
+    `Statements: ${summary.statements.pct}% (${summary.statements.covered}/${summary.statements.total})`,
+  );
+  out.push(
+    `Functions:  ${summary.functions.pct}% (${summary.functions.covered}/${summary.functions.total})`,
+  );
+  out.push(
+    `Branches:   ${summary.branches.pct}% (${summary.branches.covered}/${summary.branches.total})`,
+  );
 
   if (threshold !== undefined) {
     const pass = summary.lines.pct >= threshold;
@@ -340,12 +437,17 @@ export function formatResult(result: DiffCoverageResult, threshold?: number): st
 
   out.push("\n--- Per File ---");
   for (const f of files) {
-    const icon = f.lines.pct >= 80 ? "✅" : f.lines.pct >= 50 ? "⚠️" : "❌";
+    const icon = getCoverageIcon(f.lines.pct);
     out.push(`${icon} ${f.path}`);
-    out.push(`   Lines: ${f.lines.pct}%  Stmts: ${f.statements.pct}%  Fns: ${f.functions.pct}%  Branches: ${f.branches.pct}%`);
+    out.push(
+      `   Lines: ${f.lines.pct}%  Stmts: ${f.statements.pct}%  Fns: ${f.functions.pct}%  Branches: ${f.branches.pct}%`,
+    );
     if (f.uncoveredLines.length > 0) {
       const preview = f.uncoveredLines.slice(0, 10).join(", ");
-      const more = f.uncoveredLines.length > 10 ? ` ... (+${f.uncoveredLines.length - 10})` : "";
+      const more =
+        f.uncoveredLines.length > 10
+          ? ` ... (+${f.uncoveredLines.length - 10})`
+          : "";
       out.push(`   Uncovered lines: ${preview}${more}`);
     }
   }

--- a/mcp.ts
+++ b/mcp.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { getDiffFiles, runCoverage, formatResult } from "./core.js";
+import {
+  type FileDetail,
+  formatResult,
+  getDiffFiles,
+  runCoverage,
+} from "./core.js";
 import { detectRunner } from "./runner/detect.js";
-import { resolve } from "node:path";
 
 const server = new McpServer({
   name: "diff-coverage",
@@ -15,7 +21,47 @@ const RunnerSchema = z
   .enum(["jest", "vitest", "auto"])
   .optional()
   .default("auto")
-  .describe("Test runner to use. 'auto' detects from vitest.config.* / jest.config.* / package.json");
+  .describe(
+    "Test runner to use. 'auto' detects from vitest.config.* / jest.config.* / package.json",
+  );
+
+// ─── Coverage detail helpers ──────────────────────────────────────────────────
+
+function collectUncoveredStatements(fileData: FileDetail): number[] {
+  const lines: Set<number> = new Set();
+  for (const [id, count] of Object.entries(fileData.s ?? {})) {
+    if (count === 0) {
+      const loc = fileData.statementMap?.[id]?.start?.line;
+      if (loc) lines.add(loc);
+    }
+  }
+  return [...lines].sort((a, b) => a - b);
+}
+
+function collectUncoveredFunctions(fileData: FileDetail): string[] {
+  const result: string[] = [];
+  for (const [id, count] of Object.entries(fileData.f ?? {})) {
+    if (count === 0) {
+      const fn = fileData.fnMap?.[id];
+      if (fn) result.push(`${fn.name} (line ${fn.loc?.start?.line})`);
+    }
+  }
+  return result;
+}
+
+function collectUncoveredBranches(fileData: FileDetail): number[] {
+  const lines: Set<number> = new Set();
+  for (const [id, counts] of Object.entries(fileData.b ?? {})) {
+    for (const [i, count] of counts.entries()) {
+      const loc =
+        count === 0
+          ? fileData.branchMap?.[id]?.locations?.[i]?.start?.line
+          : undefined;
+      if (loc) lines.add(loc);
+    }
+  }
+  return [...lines].sort((a, b) => a - b);
+}
 
 // ─── Tool 1: measure_diff_coverage ───────────────────────────────────────────
 
@@ -23,27 +69,33 @@ server.tool(
   "measure_diff_coverage",
   "Measure test coverage (Jest or Vitest) for files changed in the current git diff. Returns per-file coverage percentages and a summary.",
   {
-    cwd: z
-      .string()
-      .describe("Absolute path to the project root (where package.json and test config live)"),
     base: z
       .string()
       .optional()
       .default("main")
       .describe("Base branch/ref to diff against (default: main)"),
-    runner: RunnerSchema,
-    testCommand: z
+    cwd: z
       .string()
-      .optional()
-      .describe("Override test command, e.g. 'pnpm vitest' or 'npx jest --config jest.ci.config.ts'"),
+      .describe(
+        "Absolute path to the project root (where package.json and test config live)",
+      ),
     extensions: z
       .array(z.string())
       .optional()
       .describe("File extensions to include (default: ts,tsx,js,jsx)"),
+    runner: RunnerSchema,
+    testCommand: z
+      .string()
+      .optional()
+      .describe(
+        "Override test command, e.g. 'pnpm vitest' or 'npx jest --config jest.ci.config.ts'",
+      ),
     threshold: z
       .number()
       .optional()
-      .describe("Minimum line coverage % — result is marked as error if below this"),
+      .describe(
+        "Minimum line coverage % — result is marked as error if below this",
+      ),
   },
   async ({ cwd, base, runner, testCommand, extensions, threshold }) => {
     const absPath = resolve(cwd);
@@ -55,25 +107,26 @@ server.tool(
         return {
           content: [
             {
-              type: "text",
               text: "No changed source files found in diff. Either there are no changes, or all changes are in excluded files (tests, dist, node_modules).",
+              type: "text",
             },
           ],
         };
       }
 
       const result = await runCoverage(
-        { cwd: absPath, base, runner, testCommand, extensions },
-        diffFiles
+        { base, cwd: absPath, extensions, runner, testCommand },
+        diffFiles,
       );
 
       const formatted = formatResult(result, threshold);
-      const passed = threshold === undefined || result.summary.lines.pct >= threshold;
+      const passed =
+        threshold === undefined || result.summary.lines.pct >= threshold;
 
       return {
         content: [
-          { type: "text", text: formatted },
-          { type: "text", text: JSON.stringify(result, null, 2) },
+          { text: formatted, type: "text" },
+          { text: JSON.stringify(result, null, 2), type: "text" },
         ],
         isError: !passed,
       };
@@ -81,14 +134,14 @@ server.tool(
       return {
         content: [
           {
-            type: "text",
             text: `Error running coverage: ${err instanceof Error ? err.message : String(err)}`,
+            type: "text",
           },
         ],
         isError: true,
       };
     }
-  }
+  },
 );
 
 // ─── Tool 2: get_diff_files ───────────────────────────────────────────────────
@@ -97,8 +150,12 @@ server.tool(
   "get_diff_files",
   "List source files changed in the current git diff without running tests. Useful to preview what will be measured.",
   {
+    base: z
+      .string()
+      .optional()
+      .default("main")
+      .describe("Base branch to diff against"),
     cwd: z.string().describe("Absolute path to the project root"),
-    base: z.string().optional().default("main").describe("Base branch to diff against"),
     extensions: z.array(z.string()).optional(),
   },
   async ({ cwd, base, extensions }) => {
@@ -106,7 +163,9 @@ server.tool(
       const files = await getDiffFiles(resolve(cwd), base, extensions);
 
       if (files.length === 0) {
-        return { content: [{ type: "text", text: "No changed source files found." }] };
+        return {
+          content: [{ text: "No changed source files found.", type: "text" }],
+        };
       }
 
       const lines = files.map(
@@ -114,21 +173,29 @@ server.tool(
           `${f.path}  (+${f.additions} additions, -${f.deletions} deletions)` +
           (f.addedLines.length > 0
             ? `\n  Added lines: ${f.addedLines.slice(0, 10).join(", ")}${f.addedLines.length > 10 ? " ..." : ""}`
-            : "")
+            : ""),
       );
 
       return {
         content: [
-          { type: "text", text: `Changed files (${files.length}):\n\n${lines.join("\n\n")}` },
+          {
+            text: `Changed files (${files.length}):\n\n${lines.join("\n\n")}`,
+            type: "text",
+          },
         ],
       };
     } catch (err) {
       return {
-        content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        content: [
+          {
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            type: "text",
+          },
+        ],
         isError: true,
       };
     }
-  }
+  },
 );
 
 // ─── Tool 3: get_uncovered_lines ──────────────────────────────────────────────
@@ -141,73 +208,48 @@ server.tool(
     filePath: z.string().describe("Relative path to the file (from cwd)"),
   },
   async ({ cwd, filePath }) => {
-    const { readFile } = await import("node:fs/promises");
-    const { resolve } = await import("node:path");
-
     try {
       const coveragePath = resolve(cwd, "coverage/coverage-final.json");
       const raw = await readFile(coveragePath, "utf-8");
-      const data = JSON.parse(raw);
+      const data = JSON.parse(raw) as Record<string, FileDetail>;
 
-      const absFilePath = resolve(cwd, filePath);
-      const fileData = data[absFilePath];
+      const fileData = data[resolve(cwd, filePath)];
 
       if (!fileData) {
         return {
           content: [
             {
-              type: "text",
               text: `No coverage data found for ${filePath}. Make sure measure_diff_coverage was run first.`,
+              type: "text",
             },
           ],
         };
       }
 
-      const uncoveredStatements: number[] = [];
-      const uncoveredFunctions: string[] = [];
-      const uncoveredBranches: number[] = [];
-
-      for (const [id, count] of Object.entries(fileData.s ?? {})) {
-        if ((count as number) === 0) {
-          const loc = fileData.statementMap?.[id]?.start?.line;
-          if (loc) uncoveredStatements.push(loc);
-        }
-      }
-
-      for (const [id, count] of Object.entries(fileData.f ?? {})) {
-        if ((count as number) === 0) {
-          const fn = fileData.fnMap?.[id];
-          if (fn) uncoveredFunctions.push(`${fn.name} (line ${fn.loc?.start?.line})`);
-        }
-      }
-
-      for (const [id, counts] of Object.entries(fileData.b ?? {})) {
-        const arr = counts as number[];
-        arr.forEach((count, i) => {
-          if (count === 0) {
-            const loc = fileData.branchMap?.[id]?.locations?.[i]?.start?.line;
-            if (loc) uncoveredBranches.push(loc);
-          }
-        });
-      }
+      const stmtLines = collectUncoveredStatements(fileData);
+      const fnNames = collectUncoveredFunctions(fileData);
+      const branchLines = collectUncoveredBranches(fileData);
 
       const lines = [
         `=== Uncovered Code in ${filePath} ===\n`,
-        `Uncovered statements at lines: ${[...new Set(uncoveredStatements)].sort((a, b) => a - b).join(", ") || "none"}`,
-        `Uncovered functions: ${uncoveredFunctions.join(", ") || "none"}`,
-        `Uncovered branch locations at lines: ${[...new Set(uncoveredBranches)].sort((a, b) => a - b).join(", ") || "none"}`,
+        `Uncovered statements at lines: ${stmtLines.join(", ") || "none"}`,
+        `Uncovered functions: ${fnNames.join(", ") || "none"}`,
+        `Uncovered branch locations at lines: ${branchLines.join(", ") || "none"}`,
       ];
 
-      return { content: [{ type: "text", text: lines.join("\n") }] };
+      return { content: [{ text: lines.join("\n"), type: "text" }] };
     } catch (err) {
       return {
         content: [
-          { type: "text", text: `Error reading coverage data: ${err instanceof Error ? err.message : String(err)}` },
+          {
+            text: `Error reading coverage data: ${err instanceof Error ? err.message : String(err)}`,
+            type: "text",
+          },
         ],
         isError: true,
       };
     }
-  }
+  },
 );
 
 // ─── Tool 4: detect_runner ────────────────────────────────────────────────────
@@ -222,15 +264,20 @@ server.tool(
     try {
       const runner = await detectRunner(resolve(cwd));
       return {
-        content: [{ type: "text", text: `Detected test runner: ${runner}` }],
+        content: [{ text: `Detected test runner: ${runner}`, type: "text" }],
       };
     } catch (err) {
       return {
-        content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        content: [
+          {
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            type: "text",
+          },
+        ],
         isError: true,
       };
     }
-  }
+  },
 );
 
 // Start server

--- a/package.json
+++ b/package.json
@@ -1,17 +1,6 @@
 {
-  "name": "diff-coverage",
-  "version": "0.1.0",
-  "description": "Git差分に対するJestテストカバレッジを計測するCLI & MCPサーバー",
-  "type": "module",
   "bin": {
     "diff-coverage": "./dist/cli.js"
-  },
-  "main": "./dist/core.js",
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "start": "node dist/cli.js",
-    "mcp": "node dist/mcp.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -19,11 +8,26 @@
     "execa": "^9.5.2",
     "zod": "^3.24.0"
   },
+  "description": "Git差分に対するJestテストカバレッジを計測するCLI & MCPサーバー",
   "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
     "@types/node": "^22.0.0",
     "typescript": "^5.8.0"
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "main": "./dist/core.js",
+  "name": "diff-coverage",
+  "scripts": {
+    "build": "tsc",
+    "check": "biome check .",
+    "dev": "tsc --watch",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
+    "mcp": "node dist/mcp.js",
+    "start": "node dist/cli.js"
+  },
+  "type": "module",
+  "version": "0.1.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.13
+        version: 2.4.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -29,6 +32,63 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -479,6 +539,41 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    optional: true
 
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:

--- a/runner/detect.ts
+++ b/runner/detect.ts
@@ -8,7 +8,7 @@ const VITEST_CONFIG_FILES = [
   "vitest.config.mts",
   "vitest.config.js",
   "vitest.config.mjs",
-  "vite.config.ts",   // vitest can live inside vite config
+  "vite.config.ts", // vitest can live inside vite config
   "vite.config.mts",
   "vite.config.js",
 ];
@@ -30,45 +30,36 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-/**
- * Detect which test runner is configured in the project.
- *
- * Priority:
- * 1. Explicit vitest config file  → vitest
- * 2. Explicit jest config file    → jest
- * 3. package.json "jest" key      → jest
- * 4. package.json "scripts" containing "vitest" → vitest
- * 5. Fall back to jest
- */
-export async function detectRunner(cwd: string): Promise<RunnerType> {
-  // Check vitest config files first (more specific wins)
+async function checkViteConfig(cfgPath: string): Promise<boolean> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const content = await readFile(cfgPath, "utf-8");
+    return content.includes("vitest") || content.includes("test:");
+  } catch {
+    return false;
+  }
+}
+
+async function checkVitestConfigs(cwd: string): Promise<RunnerType | null> {
   for (const cfg of VITEST_CONFIG_FILES) {
-    if (await fileExists(resolve(cwd, cfg))) {
-      // vite.config.* might not have vitest configured — peek inside
-      if (cfg.startsWith("vite.config")) {
-        try {
-          const { readFile } = await import("node:fs/promises");
-          const content = await readFile(resolve(cwd, cfg), "utf-8");
-          if (content.includes("vitest") || content.includes("test:")) {
-            return "vitest";
-          }
-        } catch {
-          // can't read — skip
-        }
-      } else {
-        return "vitest";
-      }
+    if (!(await fileExists(resolve(cwd, cfg)))) continue;
+    if (cfg.startsWith("vite.config")) {
+      if (await checkViteConfig(resolve(cwd, cfg))) return "vitest";
+    } else {
+      return "vitest";
     }
   }
+  return null;
+}
 
-  // Check jest config files
+async function checkJestConfigs(cwd: string): Promise<RunnerType | null> {
   for (const cfg of JEST_CONFIG_FILES) {
-    if (await fileExists(resolve(cwd, cfg))) {
-      return "jest";
-    }
+    if (await fileExists(resolve(cwd, cfg))) return "jest";
   }
+  return null;
+}
 
-  // Check package.json
+async function checkPackageJson(cwd: string): Promise<RunnerType | null> {
   try {
     const { readFile } = await import("node:fs/promises");
     const pkgRaw = await readFile(resolve(cwd, "package.json"), "utf-8");
@@ -81,16 +72,30 @@ export async function detectRunner(cwd: string): Promise<RunnerType> {
     if (allScripts.includes("vitest")) return "vitest";
     if (allScripts.includes("jest")) return "jest";
 
-    // Check devDependencies / dependencies
-    const deps = {
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    };
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
     if (deps?.vitest) return "vitest";
     if (deps?.jest) return "jest";
   } catch {
     // no package.json or parse error
   }
+  return null;
+}
 
-  return "jest"; // default
+/**
+ * Detect which test runner is configured in the project.
+ *
+ * Priority:
+ * 1. Explicit vitest config file  → vitest
+ * 2. Explicit jest config file    → jest
+ * 3. package.json "jest" key      → jest
+ * 4. package.json "scripts" containing "vitest" → vitest
+ * 5. Fall back to jest
+ */
+export async function detectRunner(cwd: string): Promise<RunnerType> {
+  return (
+    (await checkVitestConfigs(cwd)) ??
+    (await checkJestConfigs(cwd)) ??
+    (await checkPackageJson(cwd)) ??
+    "jest"
+  );
 }

--- a/runner/jest.ts
+++ b/runner/jest.ts
@@ -3,9 +3,9 @@ import type { DiffFile, RunOptions } from "../core.js";
 
 export async function runJest(
   options: RunOptions,
-  diffFiles: DiffFile[]
+  diffFiles: DiffFile[],
 ): Promise<void> {
-  const { cwd, testCommand, extensions } = options;
+  const { cwd, testCommand } = options;
   const filePaths = diffFiles.map((f) => f.path);
 
   const jestArgs = [

--- a/runner/vitest.ts
+++ b/runner/vitest.ts
@@ -1,6 +1,6 @@
-import { execa } from "execa";
 import { readFile, writeFile } from "node:fs/promises";
-import { resolve, relative } from "node:path";
+import { resolve } from "node:path";
+import { execa } from "execa";
 import type { DiffFile, RunOptions } from "../core.js";
 
 // Vitest outputs coverage to coverage/ by default, same as Jest.
@@ -9,7 +9,7 @@ import type { DiffFile, RunOptions } from "../core.js";
 // We run all tests but restrict coverage collection to diff files only.
 export async function runVitest(
   options: RunOptions,
-  diffFiles: DiffFile[]
+  diffFiles: DiffFile[],
 ): Promise<void> {
   const { cwd, testCommand } = options;
   const filePaths = diffFiles.map((f) => f.path);
@@ -21,10 +21,10 @@ export async function runVitest(
     "run",
     "--coverage",
     "--coverage.enabled=true",
-    "--coverage.provider=v8",          // v8 is faster; istanbul also works
+    "--coverage.provider=v8", // v8 is faster; istanbul also works
     "--coverage.reporter=json",
     "--coverage.reporter=json-summary",
-    "--coverage.all=false",            // only instrument files that are imported
+    "--coverage.all=false", // only instrument files that are imported
     ...includeArgs,
     "--passWithNoTests",
   ];
@@ -46,13 +46,16 @@ export async function runVitest(
 
 // Vitest v8 sometimes writes relative paths as keys instead of absolute paths.
 // Normalize to absolute paths to match Jest's output format.
-async function normalizeVitestCoverage(cwd: string): Promise<void> {
-  const finalPath = resolve(cwd, "coverage/coverage-final.json");
+async function normalizeCoverageFile(
+  filePath: string,
+  cwd: string,
+  preserveKey?: (key: string) => boolean,
+): Promise<void> {
   let raw: string;
   try {
-    raw = await readFile(finalPath, "utf-8");
+    raw = await readFile(filePath, "utf-8");
   } catch {
-    return; // file doesn't exist yet — nothing to normalize
+    return;
   }
 
   const data: Record<string, unknown> = JSON.parse(raw);
@@ -60,47 +63,25 @@ async function normalizeVitestCoverage(cwd: string): Promise<void> {
   let changed = false;
 
   for (const [key, value] of Object.entries(data)) {
-    // If key is already absolute, keep as-is
-    if (key.startsWith("/") || key.match(/^[A-Z]:\\/)) {
+    if (preserveKey?.(key) || key.startsWith("/") || key.match(/^[A-Z]:\\/)) {
       normalized[key] = value;
     } else {
-      // Relative path → make absolute
       normalized[resolve(cwd, key)] = value;
       changed = true;
     }
   }
 
   if (changed) {
-    await writeFile(finalPath, JSON.stringify(normalized), "utf-8");
+    await writeFile(filePath, JSON.stringify(normalized), "utf-8");
   }
+}
 
-  // Same for coverage-summary.json
+async function normalizeVitestCoverage(cwd: string): Promise<void> {
+  const finalPath = resolve(cwd, "coverage/coverage-final.json");
   const summaryPath = resolve(cwd, "coverage/coverage-summary.json");
-  let rawSummary: string;
-  try {
-    rawSummary = await readFile(summaryPath, "utf-8");
-  } catch {
-    return;
-  }
 
-  const summaryData: Record<string, unknown> = JSON.parse(rawSummary);
-  const normalizedSummary: Record<string, unknown> = {};
-  let summaryChanged = false;
-
-  for (const [key, value] of Object.entries(summaryData)) {
-    if (key === "total") {
-      normalizedSummary[key] = value;
-    } else if (key.startsWith("/") || key.match(/^[A-Z]:\\/)) {
-      normalizedSummary[key] = value;
-    } else {
-      normalizedSummary[resolve(cwd, key)] = value;
-      summaryChanged = true;
-    }
-  }
-
-  if (summaryChanged) {
-    await writeFile(summaryPath, JSON.stringify(normalizedSummary), "utf-8");
-  }
+  await normalizeCoverageFile(finalPath, cwd);
+  await normalizeCoverageFile(summaryPath, cwd, (key) => key === "total");
 }
 
 export const VITEST_COVERAGE_DIR = "coverage";


### PR DESCRIPTION
- Add biome.jsonc with curio-derived rules (formatter, linter, assist)
- Remove React/mobile-specific rules not applicable to this Node.js project
- Add check/lint/format scripts to package.json
- Refactor source files to pass all Biome checks:
  - Extract helper functions to reduce cognitive complexity
  - Replace `any` types with proper typed structures (FileDetail, etc.)
  - Fix import ordering, key sorting, and other style rules

https://claude.ai/code/session_011BrDyXFmttCZ5pPyKfo5wh