### PR TITLE
Add typecheck command to run tsc on diff files

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { Command } from "commander";
-import { formatResult, getDiffFiles, runCoverage } from "./core.js";
+import {
+  formatResult,
+  formatTypecheckResult,
+  getDiffFiles,
+  runCoverage,
+  runTypecheck,
+} from "./core.js";
 import { detectRunner, type RunnerType } from "./runner/detect.js";
 
 type MeasureOpts = {
@@ -152,6 +158,54 @@ program
     const cwd = resolve(opts.cwd);
     const runner = await detectRunner(cwd);
     console.log(`Detected runner: ${runner}`);
+  });
+
+program
+  .command("typecheck")
+  .description("Run TypeScript type-check on changed files")
+  .option("-b, --base <branch>", "Base branch to diff against", "main")
+  .option("-c, --cwd <path>", "Project root directory", process.cwd())
+  .option("--cmd <command>", "Override typecheck command (e.g. 'pnpm tsc --noEmit')")
+  .option(
+    "--ext <extensions>",
+    "Comma-separated file extensions",
+    "ts,tsx,mts,cts",
+  )
+  .option("--json", "Output raw JSON")
+  .action(async (opts) => {
+    const cwd = resolve(opts.cwd);
+    const extensions = opts.ext.split(",").map((e: string) => e.trim());
+
+    console.error(`🔍 Type-checking diff against ${opts.base}...`);
+
+    try {
+      const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
+
+      if (diffFiles.length === 0) {
+        console.log("No changed TypeScript files found.");
+        process.exit(0);
+      }
+
+      console.error(
+        `📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`,
+      );
+      console.error("⚙️  Running tsc...\n");
+
+      const result = await runTypecheck(cwd, diffFiles, opts.cmd);
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatTypecheckResult(result));
+      }
+
+      if (!result.passed) {
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error("Error:", err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/core.ts
+++ b/core.ts
@@ -394,6 +394,110 @@ function emptyResult(
   };
 }
 
+// ─── Typecheck ───────────────────────────────────────────────────────────────
+
+export type TypecheckError = {
+  code: string;
+  column: number;
+  file: string;
+  line: number;
+  message: string;
+};
+
+export type TypecheckFileResult = {
+  errors: TypecheckError[];
+  path: string;
+};
+
+export type TypecheckResult = {
+  diffFiles: string[];
+  files: TypecheckFileResult[];
+  passed: boolean;
+  timestamp: string;
+  totalErrors: number;
+};
+
+export async function runTypecheck(
+  cwd: string,
+  diffFiles: DiffFile[],
+  cmd?: string,
+): Promise<TypecheckResult> {
+  const fullCmd = cmd ?? "npx tsc --noEmit";
+  const [bin, ...args] = fullCmd.split(" ");
+
+  const result = await execa(bin, args, { cwd, reject: false });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+
+  const errorRegex = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.+)$/gm;
+  const allErrors: TypecheckError[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = errorRegex.exec(output)) !== null) {
+    const [, rawFile, line, column, code, message] = match;
+    allErrors.push({
+      code,
+      column: Number.parseInt(column, 10),
+      file: relative(cwd, resolve(cwd, rawFile)),
+      line: Number.parseInt(line, 10),
+      message,
+    });
+  }
+
+  const diffPathSet = new Set(diffFiles.map((f) => f.path));
+  const diffErrors = allErrors.filter((e) => diffPathSet.has(e.file));
+
+  const errorsByFile = new Map<string, TypecheckError[]>();
+  for (const err of diffErrors) {
+    const existing = errorsByFile.get(err.file) ?? [];
+    existing.push(err);
+    errorsByFile.set(err.file, existing);
+  }
+
+  const files: TypecheckFileResult[] = diffFiles.map((df) => ({
+    errors: errorsByFile.get(df.path) ?? [],
+    path: df.path,
+  }));
+
+  return {
+    diffFiles: diffFiles.map((f) => f.path),
+    files,
+    passed: diffErrors.length === 0,
+    timestamp: new Date().toISOString(),
+    totalErrors: diffErrors.length,
+  };
+}
+
+export function formatTypecheckResult(result: TypecheckResult): string {
+  const { files, passed, totalErrors } = result;
+  const out: string[] = [];
+
+  out.push("=== TypeScript Type-Check Report ===\n");
+
+  if (files.length === 0) {
+    out.push("No changed TypeScript files found.");
+    return out.join("\n");
+  }
+
+  out.push(`Files checked: ${files.length}`);
+  out.push(`Total errors: ${totalErrors}`);
+  out.push(`Status: ${passed ? "✅ PASS" : "❌ FAIL"}`);
+
+  if (totalErrors > 0) {
+    out.push("\n--- Errors by File ---");
+    for (const f of files) {
+      if (f.errors.length === 0) continue;
+      out.push(
+        `\n❌ ${f.path} (${f.errors.length} error${f.errors.length > 1 ? "s" : ""})`,
+      );
+      for (const err of f.errors) {
+        out.push(`   ${err.line}:${err.column}  ${err.code}  ${err.message}`);
+      }
+    }
+  }
+
+  return out.join("\n");
+}
+
 // ─── Formatter ────────────────────────────────────────────────────────────────
 
 function getCoverageIcon(pct: number): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "sourceMap": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "example"]
 }


### PR DESCRIPTION
Adds a new `typecheck` CLI command that:
- Gets changed TypeScript files via git diff
- Runs `tsc --noEmit` (or a custom command via --cmd)
- Filters and reports type errors only for diff files
- Exits with code 1 if any errors are found in diff files
- Supports --json output and --ext for custom extensions

Also excludes `example/` from root tsconfig.json to prevent
compilation errors from example projects' missing dependencies.

https://claude.ai/code/session_011bo1fHHkKuqmqgtWMPLNUi