### PR TITLE
Fix jest coverage always reporting 0% by passing --collectCoverageFrom per file

### DIFF
--- a/runner/jest.ts
+++ b/runner/jest.ts
@@ -10,7 +10,7 @@ export async function runJest(
 
   const jestArgs = [
     "--coverage",
-    `--collectCoverageFrom=${filePaths.join(",")}`,
+    ...filePaths.map((p) => `--collectCoverageFrom=${p}`),
     "--coverageReporters=json-summary",
     "--coverageReporters=json",
     "--passWithNoTests",


### PR DESCRIPTION
Previously, all file paths were joined with commas into a single string
(e.g. --collectCoverageFrom=src/a.ts,src/b.ts), which Jest interprets as
one glob pattern that matches nothing. Now each file gets its own flag
(e.g. --collectCoverageFrom=src/a.ts --collectCoverageFrom=src/b.ts) so
Jest correctly collects coverage from all diff files.

https://claude.ai/code/session_01HP1twVDhp3z6sxJj9sGoP4