### PR TITLE
Add vitest with unit tests and pre-push test hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,3 +8,5 @@ pre-push:
   commands:
     typecheck:
       run: pnpm typecheck
+    test:
+      run: pnpm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@biomejs/biome": "^2.4.13",
     "@types/node": "^22.0.0",
     "lefthook": "^2.1.6",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=18"
@@ -29,6 +30,8 @@
     "mcp": "node dist/mcp.js",
     "prepare": "lefthook install",
     "start": "node dist/cli.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17))
 
 packages:
 
@@ -93,11 +96,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -109,6 +124,113 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -116,8 +238,52 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -133,6 +299,10 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -150,6 +320,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -161,6 +335,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -191,6 +368,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -210,12 +391,18 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -233,6 +420,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   express-rate-limit@8.4.0:
     resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
@@ -249,6 +440,15 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -264,6 +464,11 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -400,6 +605,83 @@ packages:
     resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -423,6 +705,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -438,6 +725,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -465,9 +755,23 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -492,6 +796,11 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -535,21 +844,52 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -575,9 +915,98 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -632,9 +1061,27 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
       hono: 4.12.15
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -658,13 +1105,130 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.19.17)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   accepts@2.0.0:
     dependencies:
@@ -681,6 +1245,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  assertion-error@2.0.1: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -708,11 +1274,15 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@6.2.2: {}
+
   commander@13.1.0: {}
 
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -735,6 +1305,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  detect-libc@2.1.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -749,11 +1321,17 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
   escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -777,6 +1355,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.4.0(express@5.2.1):
     dependencies:
@@ -820,6 +1400,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -838,6 +1422,9 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -953,6 +1540,59 @@ snapshots:
       lefthook-windows-arm64: 2.1.6
       lefthook-windows-x64: 2.1.6
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -967,6 +1607,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   negotiator@1.0.0: {}
 
   npm-run-path@6.0.0:
@@ -977,6 +1619,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -996,7 +1640,19 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
   pkce-challenge@5.0.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   pretty-ms@9.3.0:
     dependencies:
@@ -1021,6 +1677,27 @@ snapshots:
       unpipe: 1.0.0
 
   require-from-string@2.0.2: {}
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   router@2.2.0:
     dependencies:
@@ -1095,13 +1772,35 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
 
   statuses@2.0.2: {}
 
+  std-env@4.1.0: {}
+
   strip-final-newline@4.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   toidentifier@1.0.1: {}
+
+  tslib@2.8.1:
+    optional: true
 
   type-is@2.0.1:
     dependencies:
@@ -1119,9 +1818,52 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.0.10(@types/node@22.19.17):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -1,0 +1,130 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { detectRunner } from "../runner/detect.js";
+
+describe("detectRunner", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "diff-coverage-detect-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects vitest from vitest.config.ts", async () => {
+    await writeFile(join(tmpDir, "vitest.config.ts"), "export default {}");
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects vitest from vitest.config.js", async () => {
+    await writeFile(join(tmpDir, "vitest.config.js"), "module.exports = {}");
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects vitest from vitest.config.mts", async () => {
+    await writeFile(join(tmpDir, "vitest.config.mts"), "export default {}");
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects vitest from vite.config.ts when it references vitest", async () => {
+    await writeFile(
+      join(tmpDir, "vite.config.ts"),
+      "import { defineConfig } from 'vitest/config'; export default defineConfig({ test: {} })",
+    );
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("does not detect vitest from vite.config.ts without vitest references", async () => {
+    await writeFile(
+      join(tmpDir, "vite.config.ts"),
+      "import { defineConfig } from 'vite'; export default defineConfig({});",
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("detects jest from jest.config.ts", async () => {
+    await writeFile(join(tmpDir, "jest.config.ts"), "export default {}");
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("detects jest from jest.config.js", async () => {
+    await writeFile(join(tmpDir, "jest.config.js"), "module.exports = {}");
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("detects jest from jest.config.cjs", async () => {
+    await writeFile(join(tmpDir, "jest.config.cjs"), "module.exports = {}");
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("prefers vitest config file over jest config file", async () => {
+    await writeFile(join(tmpDir, "vitest.config.ts"), "export default {}");
+    await writeFile(join(tmpDir, "jest.config.ts"), "export default {}");
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects jest from package.json jest key", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ jest: { testEnvironment: "node" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("detects vitest from package.json scripts containing vitest", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects jest from package.json scripts containing jest", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { test: "jest --coverage" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("detects vitest from package.json devDependencies", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ devDependencies: { vitest: "^2.0.0" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+
+  it("detects jest from package.json devDependencies", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ devDependencies: { jest: "^29.0.0" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("falls back to jest when no config files and no package.json", async () => {
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("falls back to jest when package.json has no test-related keys", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", scripts: { build: "tsc" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+
+  it("prefers jest config over package.json vitest script when jest.config.ts exists", async () => {
+    await writeFile(join(tmpDir, "jest.config.ts"), "export default {}");
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+    );
+    expect(await detectRunner(tmpDir)).toBe("jest");
+  });
+});

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from "execa";
+import { getDiffFiles } from "../core.js";
+
+const mockExeca = vi.mocked(execa);
+
+function mockGit(...returns: Array<{ stdout: string } | Error>) {
+  let call = mockExeca;
+  for (const ret of returns) {
+    if (ret instanceof Error) {
+      call = call.mockRejectedValueOnce(ret) as typeof mockExeca;
+    } else {
+      call = call.mockResolvedValueOnce(ret as never) as typeof mockExeca;
+    }
+  }
+}
+
+describe("getDiffFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when git diff reports no changed files", async () => {
+    mockGit(new Error("no origin"), { stdout: "" });
+    const files = await getDiffFiles("/project", "main");
+    expect(files).toEqual([]);
+  });
+
+  it("returns diff files with addition and deletion counts", async () => {
+    mockGit(
+      new Error("no origin/main"),      // git rev-parse
+      { stdout: "src/foo.ts" },          // git diff --name-only
+      { stdout: "5\t2\tsrc/foo.ts" },   // git diff --numstat
+      { stdout: "@@ -1,2 +1,5 @@\n+a\n+b\n+c\n+d\n+e\n-x\n-y" }, // getAddedLines
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+    expect(files[0].additions).toBe(5);
+    expect(files[0].deletions).toBe(2);
+  });
+
+  it("extracts added line numbers from unified diff", async () => {
+    mockGit(
+      new Error("no origin/main"),
+      { stdout: "src/foo.ts" },
+      { stdout: "3\t0\tsrc/foo.ts" },
+      { stdout: "@@ -0,0 +1,3 @@\n+line1\n+line2\n+line3" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files[0].addedLines).toEqual([1, 2, 3]);
+  });
+
+  it("handles hunk starting at a non-zero line", async () => {
+    mockGit(
+      new Error("no origin/main"),
+      { stdout: "src/foo.ts" },
+      { stdout: "2\t2\tsrc/foo.ts" },
+      { stdout: "@@ -10,2 +10,2 @@\n-old1\n+new1\n-old2\n+new2" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files[0].addedLines).toEqual([10, 11]);
+  });
+
+  it("handles multiple hunks in a single file", async () => {
+    mockGit(
+      new Error("no origin/main"),
+      { stdout: "src/foo.ts" },
+      { stdout: "2\t0\tsrc/foo.ts" },
+      {
+        stdout: [
+          "@@ -1,1 +1,2 @@",
+          " unchanged",
+          "+added1",
+          "@@ -20,0 +21,1 @@",
+          "+added2",
+        ].join("\n"),
+      },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files[0].addedLines).toContain(2);
+    expect(files[0].addedLines).toContain(21);
+  });
+
+  it("filters out test files by default", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/foo.ts\nsrc/foo.test.ts\nsrc/foo.spec.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("filters out files inside a node_modules subdirectory", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/foo.ts\nlib/node_modules/pkg/index.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("filters out .d.ts declaration files", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/foo.ts\nsrc/types.d.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("filters files by provided extensions", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/foo.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main", ["ts"]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("uses origin/base ref when it exists", async () => {
+    mockGit(
+      { stdout: "abc123" },             // git rev-parse succeeds
+      { stdout: "src/foo.ts" },         // git diff --name-only
+      { stdout: "1\t0\tsrc/foo.ts" },   // git diff --numstat
+      { stdout: "" },                   // getAddedLines
+    );
+
+    await getDiffFiles("/project", "main");
+
+    const nameOnlyCall = mockExeca.mock.calls[1];
+    expect(nameOnlyCall[1]).toContain("origin/main");
+  });
+
+  it("returns empty addedLines when git diff throws for a file", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/foo.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      new Error("diff failed"),
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files[0].addedLines).toEqual([]);
+  });
+
+  it("handles multiple changed files", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "src/a.ts\nsrc/b.ts" },
+      { stdout: "3\t0\tsrc/a.ts\n2\t1\tsrc/b.ts" },
+      { stdout: "@@ -0,0 +1,3 @@\n+a\n+b\n+c" },
+      { stdout: "@@ -5,1 +5,2 @@\n-old\n+new1\n+new2" },
+    );
+
+    const files = await getDiffFiles("/project", "main");
+
+    expect(files).toHaveLength(2);
+    expect(files[0].path).toBe("src/a.ts");
+    expect(files[0].additions).toBe(3);
+    expect(files[1].path).toBe("src/b.ts");
+    expect(files[1].additions).toBe(2);
+    expect(files[1].deletions).toBe(1);
+  });
+});

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { formatResult, formatTypecheckResult } from "../core.js";
+import type {
+  DiffCoverageResult,
+  FileCoverage,
+  TypecheckResult,
+} from "../core.js";
+
+function makeFileCoverage(
+  path: string,
+  pct: number,
+  uncoveredLines: number[] = [],
+): FileCoverage {
+  const n = 10;
+  const covered = Math.round((pct / 100) * n);
+  return {
+    branches: { covered, pct, total: n },
+    functions: { covered, pct, total: n },
+    lines: { covered, pct, total: n },
+    path,
+    statements: { covered, pct, total: n },
+    uncoveredLines,
+  };
+}
+
+function makeResult(overrides?: Partial<DiffCoverageResult>): DiffCoverageResult {
+  return {
+    files: [],
+    runner: "jest",
+    summary: {
+      branches: { covered: 0, pct: 0, total: 0 },
+      coveredFiles: 0,
+      functions: { covered: 0, pct: 0, total: 0 },
+      lines: { covered: 0, pct: 0, total: 0 },
+      statements: { covered: 0, pct: 0, total: 0 },
+      totalFiles: 0,
+    },
+    timestamp: "2024-01-01T00:00:00.000Z",
+    uncoveredFiles: [],
+    ...overrides,
+  };
+}
+
+function resultWithFile(path: string, pct: number, uncoveredLines: number[] = []) {
+  const file = makeFileCoverage(path, pct, uncoveredLines);
+  return makeResult({
+    files: [file],
+    summary: {
+      branches: file.branches,
+      coveredFiles: pct > 0 ? 1 : 0,
+      functions: file.functions,
+      lines: file.lines,
+      statements: file.statements,
+      totalFiles: 1,
+    },
+  });
+}
+
+describe("formatResult", () => {
+  it("shows no-data message when files is empty", () => {
+    const out = formatResult(makeResult());
+    expect(out).toContain("No diff files found");
+  });
+
+  it("includes runner name in header", () => {
+    expect(formatResult(makeResult({ runner: "vitest" }))).toContain("vitest");
+    expect(formatResult(makeResult({ runner: "jest" }))).toContain("jest");
+  });
+
+  it("shows file count and per-file path", () => {
+    const out = formatResult(resultWithFile("src/foo.ts", 100));
+    expect(out).toContain("Files changed: 1");
+    expect(out).toContain("src/foo.ts");
+  });
+
+  it("uses ✅ icon for coverage >= 80%", () => {
+    expect(formatResult(resultWithFile("src/a.ts", 80))).toContain("✅");
+    expect(formatResult(resultWithFile("src/a.ts", 100))).toContain("✅");
+  });
+
+  it("uses ⚠️ icon for coverage >= 50% and < 80%", () => {
+    expect(formatResult(resultWithFile("src/a.ts", 50))).toContain("⚠️");
+    expect(formatResult(resultWithFile("src/a.ts", 79))).toContain("⚠️");
+  });
+
+  it("uses ❌ icon for coverage < 50%", () => {
+    expect(formatResult(resultWithFile("src/a.ts", 0))).toContain("❌");
+    expect(formatResult(resultWithFile("src/a.ts", 49))).toContain("❌");
+  });
+
+  it("shows PASS when line coverage meets threshold", () => {
+    const out = formatResult(resultWithFile("src/a.ts", 80), 80);
+    expect(out).toContain("✅ PASS");
+  });
+
+  it("shows FAIL when line coverage is below threshold", () => {
+    const out = formatResult(resultWithFile("src/a.ts", 60), 80);
+    expect(out).toContain("❌ FAIL");
+  });
+
+  it("does not show threshold line when threshold is not provided", () => {
+    const out = formatResult(resultWithFile("src/a.ts", 80));
+    expect(out).not.toContain("Threshold");
+  });
+
+  it("shows uncovered lines", () => {
+    const out = formatResult(resultWithFile("src/a.ts", 60, [5, 8, 9]));
+    expect(out).toContain("Uncovered lines: 5, 8, 9");
+  });
+
+  it("truncates uncovered lines preview to 10 and shows overflow count", () => {
+    const lines = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    const out = formatResult(resultWithFile("src/a.ts", 0, lines));
+    expect(out).toContain("(+2)");
+    expect(out).not.toContain("11, 12");
+  });
+
+  it("shows coverage metrics in summary", () => {
+    const out = formatResult(resultWithFile("src/a.ts", 80));
+    expect(out).toContain("Lines:");
+    expect(out).toContain("Statements:");
+    expect(out).toContain("Functions:");
+    expect(out).toContain("Branches:");
+  });
+});
+
+describe("formatTypecheckResult", () => {
+  function makeTypecheckResult(overrides?: Partial<TypecheckResult>): TypecheckResult {
+    return {
+      diffFiles: [],
+      files: [],
+      passed: true,
+      timestamp: "2024-01-01T00:00:00.000Z",
+      totalErrors: 0,
+      ...overrides,
+    };
+  }
+
+  it("shows no-files message when files list is empty", () => {
+    const out = formatTypecheckResult(makeTypecheckResult());
+    expect(out).toContain("No changed TypeScript files found");
+  });
+
+  it("shows file count and error count", () => {
+    const out = formatTypecheckResult(
+      makeTypecheckResult({
+        diffFiles: ["src/foo.ts"],
+        files: [{ errors: [], path: "src/foo.ts" }],
+        passed: true,
+        totalErrors: 0,
+      }),
+    );
+    expect(out).toContain("Files checked: 1");
+    expect(out).toContain("Total errors: 0");
+  });
+
+  it("shows PASS status when no errors", () => {
+    const out = formatTypecheckResult(
+      makeTypecheckResult({
+        diffFiles: ["src/foo.ts"],
+        files: [{ errors: [], path: "src/foo.ts" }],
+        passed: true,
+        totalErrors: 0,
+      }),
+    );
+    expect(out).toContain("✅ PASS");
+  });
+
+  it("shows FAIL status when there are errors", () => {
+    const out = formatTypecheckResult(
+      makeTypecheckResult({
+        diffFiles: ["src/foo.ts"],
+        files: [
+          {
+            errors: [
+              {
+                code: "TS2322",
+                column: 5,
+                file: "src/foo.ts",
+                line: 10,
+                message: "Type 'string' is not assignable to type 'number'.",
+              },
+            ],
+            path: "src/foo.ts",
+          },
+        ],
+        passed: false,
+        totalErrors: 1,
+      }),
+    );
+    expect(out).toContain("❌ FAIL");
+  });
+
+  it("shows error details when errors exist", () => {
+    const out = formatTypecheckResult(
+      makeTypecheckResult({
+        diffFiles: ["src/foo.ts"],
+        files: [
+          {
+            errors: [
+              {
+                code: "TS2322",
+                column: 5,
+                file: "src/foo.ts",
+                line: 10,
+                message: "Type 'string' is not assignable to type 'number'.",
+              },
+            ],
+            path: "src/foo.ts",
+          },
+        ],
+        passed: false,
+        totalErrors: 1,
+      }),
+    );
+    expect(out).toContain("TS2322");
+    expect(out).toContain("10:5");
+    expect(out).toContain("src/foo.ts");
+  });
+
+  it("does not show error section when no errors", () => {
+    const out = formatTypecheckResult(
+      makeTypecheckResult({
+        diffFiles: ["src/foo.ts"],
+        files: [{ errors: [], path: "src/foo.ts" }],
+        passed: true,
+        totalErrors: 0,
+      }),
+    );
+    expect(out).not.toContain("Errors by File");
+  });
+});

--- a/tests/runner/jest.test.ts
+++ b/tests/runner/jest.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+}));
+
+import { execa } from "execa";
+import { runJest } from "../../runner/jest.js";
+import type { DiffFile, RunOptions } from "../../core.js";
+
+const mockExeca = vi.mocked(execa);
+
+describe("runJest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes jest with coverage flags via npx by default", async () => {
+    const options: RunOptions = { cwd: "/project" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [1, 2], additions: 2, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    expect(mockExeca).toHaveBeenCalledOnce();
+    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("npx");
+    expect(args).toContain("jest");
+    expect(args).toContain("--coverage");
+    expect(args).toContain("--passWithNoTests");
+    expect(args).toContain("--findRelatedTests");
+  });
+
+  it("uses custom test command when provided", async () => {
+    const options: RunOptions = { cwd: "/project", testCommand: "pnpm jest" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/bar.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("pnpm");
+    expect(args[0]).toBe("jest");
+  });
+
+  it("adds --collectCoverageFrom for each diff file", async () => {
+    const options: RunOptions = { cwd: "/project" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+      { addedLines: [], additions: 2, deletions: 0, path: "src/b.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    const args = mockExeca.mock.calls[0][1] as string[];
+    expect(args).toContain("--collectCoverageFrom=src/a.ts");
+    expect(args).toContain("--collectCoverageFrom=src/b.ts");
+  });
+
+  it("passes diff file paths as positional arguments for --findRelatedTests", async () => {
+    const options: RunOptions = { cwd: "/project" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+      { addedLines: [], additions: 1, deletions: 0, path: "src/b.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    const args = mockExeca.mock.calls[0][1] as string[];
+    expect(args).toContain("src/a.ts");
+    expect(args).toContain("src/b.ts");
+  });
+
+  it("sets CI=true in environment", async () => {
+    const options: RunOptions = { cwd: "/project" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    const execaOptions = mockExeca.mock.calls[0][2] as { env: Record<string, string> };
+    expect(execaOptions.env).toMatchObject({ CI: "true" });
+  });
+
+  it("uses coverage reporters json-summary and json", async () => {
+    const options: RunOptions = { cwd: "/project" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+    ];
+
+    await runJest(options, diffFiles);
+
+    const args = mockExeca.mock.calls[0][1] as string[];
+    expect(args).toContain("--coverageReporters=json-summary");
+    expect(args).toContain("--coverageReporters=json");
+  });
+});

--- a/tests/runner/vitest-runner.test.ts
+++ b/tests/runner/vitest-runner.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+}));
+
+import { execa } from "execa";
+import { runVitest } from "../../runner/vitest.js";
+import type { DiffFile, RunOptions } from "../../core.js";
+
+const mockExeca = vi.mocked(execa);
+
+describe("runVitest", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await mkdtemp(join(tmpdir(), "diff-coverage-vitest-"));
+    await mkdir(join(tmpDir, "coverage"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("invokes vitest with coverage flags via npx by default", async () => {
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [1, 2], additions: 2, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    expect(mockExeca).toHaveBeenCalledOnce();
+    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("npx");
+    expect(args).toContain("vitest");
+    expect(args).toContain("run");
+    expect(args).toContain("--coverage");
+    expect(args).toContain("--coverage.enabled=true");
+    expect(args).toContain("--coverage.provider=v8");
+  });
+
+  it("uses custom test command when provided", async () => {
+    const options: RunOptions = { cwd: tmpDir, testCommand: "pnpm vitest" };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("pnpm");
+    expect(args[0]).toBe("vitest");
+  });
+
+  it("adds --coverage.include for each diff file", async () => {
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+      { addedLines: [], additions: 2, deletions: 0, path: "src/b.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const args = mockExeca.mock.calls[0][1] as string[];
+    const includeValues = args
+      .map((a, i) => (a === "--coverage.include" ? args[i + 1] : null))
+      .filter(Boolean);
+    expect(includeValues).toContain("src/a.ts");
+    expect(includeValues).toContain("src/b.ts");
+  });
+
+  it("uses json and json-summary coverage reporters", async () => {
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const args = mockExeca.mock.calls[0][1] as string[];
+    expect(args).toContain("--coverage.reporter=json");
+    expect(args).toContain("--coverage.reporter=json-summary");
+  });
+
+  it("sets CI=true in environment", async () => {
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const execaOptions = mockExeca.mock.calls[0][2] as { env: Record<string, string> };
+    expect(execaOptions.env).toMatchObject({ CI: "true" });
+  });
+
+  it("normalizes relative paths to absolute paths in coverage-final.json", async () => {
+    const coverageData = {
+      "src/foo.ts": {
+        s: { "0": 1, "1": 0 },
+        statementMap: {
+          "0": { start: { line: 1 } },
+          "1": { start: { line: 5 } },
+        },
+      },
+    };
+    await writeFile(
+      join(tmpDir, "coverage/coverage-final.json"),
+      JSON.stringify(coverageData),
+    );
+
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const normalized = JSON.parse(
+      await readFile(join(tmpDir, "coverage/coverage-final.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    const keys = Object.keys(normalized);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toMatch(/^\//);
+    expect(keys[0]).toContain("src/foo.ts");
+  });
+
+  it("preserves absolute paths in coverage-final.json unchanged", async () => {
+    const absKey = join(tmpDir, "src/foo.ts");
+    const coverageData = {
+      [absKey]: { s: { "0": 1 }, statementMap: { "0": { start: { line: 1 } } } },
+    };
+    await writeFile(
+      join(tmpDir, "coverage/coverage-final.json"),
+      JSON.stringify(coverageData),
+    );
+
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const normalized = JSON.parse(
+      await readFile(join(tmpDir, "coverage/coverage-final.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(Object.keys(normalized)).toContain(absKey);
+  });
+
+  it("preserves 'total' key in coverage-summary.json", async () => {
+    const summaryData = {
+      total: {
+        branches: { covered: 5, pct: 50, total: 10 },
+        functions: { covered: 5, pct: 50, total: 10 },
+        lines: { covered: 5, pct: 50, total: 10 },
+        statements: { covered: 5, pct: 50, total: 10 },
+      },
+      "src/foo.ts": {
+        branches: { covered: 5, pct: 50, total: 10 },
+        functions: { covered: 5, pct: 50, total: 10 },
+        lines: { covered: 5, pct: 50, total: 10 },
+        statements: { covered: 5, pct: 50, total: 10 },
+      },
+    };
+    await writeFile(
+      join(tmpDir, "coverage/coverage-summary.json"),
+      JSON.stringify(summaryData),
+    );
+
+    const options: RunOptions = { cwd: tmpDir };
+    const diffFiles: DiffFile[] = [
+      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
+    ];
+
+    await runVitest(options, diffFiles);
+
+    const normalized = JSON.parse(
+      await readFile(join(tmpDir, "coverage/coverage-summary.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(normalized.total).toBeDefined();
+    const nonTotalKeys = Object.keys(normalized).filter((k) => k !== "total");
+    expect(nonTotalKeys[0]).toMatch(/^\//);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
- Install vitest as devDependency
- Add vitest.config.ts with node environment
- Add test/test:watch scripts to package.json
- Add 61 unit tests covering:
  - format.test.ts: formatResult and formatTypecheckResult (pure functions)
  - detect.test.ts: detectRunner with real temp directories
  - runner/jest.test.ts: runJest command building (mocked execa)
  - runner/vitest-runner.test.ts: runVitest commands and coverage normalization
  - diff.test.ts: getDiffFiles git diff parsing (mocked execa)
- Update lefthook.yml to run pnpm test on pre-push for regression detection

https://claude.ai/code/session_016CLfuPZ74ZqXbfhyLZihXm