### PR TITLE
Colocate test files with their source modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm format         # Auto-format with Biome
 
 Run a single test file:
 ```bash
-pnpm vitest run tests/diff.test.ts
+pnpm vitest run src/diff.test.ts
 ```
 
 Run the compiled CLI against an example project:
@@ -85,4 +85,4 @@ Key rules to be aware of:
 
 **Process execution:** All external processes (git, jest, vitest, tsc) are run via `execa`. Tests mock `execa` to avoid real process spawning.
 
-**Test files** live in `tests/` and mirror the source structure. Runner tests live in `tests/runner/`.
+**Test files** are colocated with their source files in `src/`. Each test file sits next to the module it tests (e.g. `src/runner/jest.test.ts` tests `src/runner/jest.ts`).

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -5,7 +5,7 @@ vi.mock("execa", () => ({
 }));
 
 import { execa } from "execa";
-import { getDiffFiles } from "../src/core.js";
+import { getDiffFiles } from "./core.js";
 
 const mockExeca = vi.mocked(execa);
 

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatResult, formatTypecheckResult } from "../src/core.js";
+import { formatResult, formatTypecheckResult } from "./core.js";
 import type {
   DiffCoverageResult,
   FileCoverage,
   TypecheckResult,
-} from "../src/core.js";
+} from "./core.js";
 
 function makeFileCoverage(
   path: string,

--- a/src/runner/detect.test.ts
+++ b/src/runner/detect.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { detectRunner } from "../src/runner/detect.js";
+import { detectRunner } from "./detect.js";
 
 describe("detectRunner", () => {
   let tmpDir: string;

--- a/src/runner/jest.test.ts
+++ b/src/runner/jest.test.ts
@@ -5,8 +5,8 @@ vi.mock("execa", () => ({
 }));
 
 import { execa } from "execa";
-import { runJest } from "../../src/runner/jest.js";
-import type { DiffFile, RunOptions } from "../../src/core.js";
+import { runJest } from "./jest.js";
+import type { DiffFile, RunOptions } from "../core.js";
 
 const mockExeca = vi.mocked(execa);
 

--- a/src/runner/vitest-runner.test.ts
+++ b/src/runner/vitest-runner.test.ts
@@ -8,8 +8,8 @@ vi.mock("execa", () => ({
 }));
 
 import { execa } from "execa";
-import { runVitest } from "../../src/runner/vitest.js";
-import type { DiffFile, RunOptions } from "../../src/core.js";
+import { runVitest } from "./vitest.js";
+import type { DiffFile, RunOptions } from "../core.js";
 
 const mockExeca = vi.mocked(execa);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "example"]
+  "exclude": ["node_modules", "dist", "example", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Move all test files from tests/ into src/ next to the modules they test,
update vitest.config.ts include pattern, exclude test files from tsc
compilation in tsconfig.json, and update CLAUDE.md accordingly.

https://claude.ai/code/session_018jLkWSAsDApPnnjxkMQvgz