### PR TITLE
add diff-coverage skill for Claude Code

### DIFF
--- a/.claude/skills/diff-coverage/SKILL.md
+++ b/.claude/skills/diff-coverage/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: diff-coverage
+description: Measure test coverage only for files changed in a git diff using Jest or Vitest. Use when checking test coverage of code changes, reviewing uncovered lines in a PR, or enforcing coverage thresholds on changed files.
+when_to_use: Triggered by requests like "check coverage for my changes", "what lines are uncovered in the diff", "measure diff coverage", "are my changes tested", or "coverage report for this PR".
+allowed-tools: Bash(node *)
+disable-model-invocation: false
+---
+
+# diff-coverage
+
+Measures test coverage scoped only to files changed in a git diff. Reports per-file coverage, uncovered lines, and optionally enforces a threshold (exit code 1 on failure).
+
+## Prerequisites
+
+The CLI must be compiled before first use. Run once from the project root:
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../node_modules/.bin/tsc" --project "${CLAUDE_SKILL_DIR}/../../../tsconfig.json"
+```
+
+Or equivalently: `pnpm build` inside the project root.
+
+## Commands
+
+All commands use `node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js"` as the base.
+
+### measure — run coverage for changed files
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure \
+  --cwd <project-dir> \
+  --base <git-ref>
+```
+
+Options:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cwd <path>` | `.` | Target project directory |
+| `--base <ref>` | `main` | Base git ref to diff against |
+| `--threshold <n>` | none | Fail (exit 1) if coverage < n% |
+| `--runner <jest\|vitest>` | auto-detected | Force a specific test runner |
+
+Example — measure coverage for changes vs `main` in the current project:
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure --cwd . --base main
+```
+
+Example — enforce 80% threshold:
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure --cwd . --base main --threshold 80
+```
+
+### diff — list changed files and added lines
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" diff --cwd . --base main
+```
+
+### detect — identify the test runner
+
+```bash
+node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" detect --cwd .
+```
+
+## Workflow
+
+1. Run `measure` against the target project's working directory
+2. Review per-file coverage percentages and uncovered line numbers
+3. Focus attention on uncovered lines that correspond to added code
+4. If `--threshold` is set and fails, report exit code 1 to the user
+
+## Output interpretation
+
+- ✅ File meets the threshold (or no threshold set)
+- ⚠️ File is below the threshold
+- ❌ File has no coverage data
+
+Uncovered lines listed under each file are the **added** lines (from the diff) that have no test coverage.

--- a/skills/diff-coverage/SKILL.md
+++ b/skills/diff-coverage/SKILL.md
@@ -3,36 +3,41 @@ name: diff-coverage
 description: Measure test coverage only for files changed in a git diff using Jest or Vitest. Use when checking test coverage of code changes, reviewing uncovered lines in a PR, or enforcing coverage thresholds on changed files.
 when_to_use: Triggered by requests like "check coverage for my changes", "what lines are uncovered in the diff", "measure diff coverage", "are my changes tested", or "coverage report for this PR".
 allowed-tools: Bash(node *)
-disable-model-invocation: false
 ---
 
 # diff-coverage
 
 Measures test coverage scoped only to files changed in a git diff. Reports per-file coverage, uncovered lines, and optionally enforces a threshold (exit code 1 on failure).
 
-## Prerequisites
+## Installation
 
-The CLI must be compiled before first use. Run once from the project root:
+Install as a project-scope skill from the diff-coverage repository root (requires a prior `pnpm build`):
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../node_modules/.bin/tsc" --project "${CLAUDE_SKILL_DIR}/../../../tsconfig.json"
+gh skill install ksugawara61/diff-coverage --scope project
 ```
 
-Or equivalently: `pnpm build` inside the project root.
+Or as a user-scope skill (falls back to `npx diff-coverage` if local build is unavailable):
+
+```bash
+gh skill install ksugawara61/diff-coverage --scope user
+```
 
 ## Commands
 
-All commands use `node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js"` as the base.
+All commands are invoked via the bundled wrapper:
+
+```
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" <command> [options]
+```
 
 ### measure — run coverage for changed files
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure \
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" measure \
   --cwd <project-dir> \
   --base <git-ref>
 ```
-
-Options:
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -44,25 +49,25 @@ Options:
 Example — measure coverage for changes vs `main` in the current project:
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure --cwd . --base main
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" measure --cwd . --base main
 ```
 
 Example — enforce 80% threshold:
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" measure --cwd . --base main --threshold 80
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" measure --cwd . --base main --threshold 80
 ```
 
 ### diff — list changed files and added lines
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" diff --cwd . --base main
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" diff --cwd . --base main
 ```
 
 ### detect — identify the test runner
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/../../../dist/cli.js" detect --cwd .
+node "${CLAUDE_SKILL_DIR}/scripts/run.cjs" detect --cwd .
 ```
 
 ## Workflow

--- a/skills/diff-coverage/scripts/run.cjs
+++ b/skills/diff-coverage/scripts/run.cjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Wrapper to locate the diff-coverage CLI and invoke it with node.
+//
+// Installed as a project-scope skill (.claude/skills/diff-coverage/scripts/):
+//   __dirname resolves to <project>/.claude/skills/diff-coverage/scripts/
+//   so ../../../../ reaches the project root where dist/cli.js lives.
+//
+// Installed as a user-scope skill (~/.claude/skills/diff-coverage/scripts/):
+//   dist/cli.js won't be found, falls back to npx diff-coverage.
+
+const { spawnSync } = require("child_process");
+const { existsSync } = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+
+const projectRoot = path.resolve(__dirname, "../../../../");
+const localCli = path.join(projectRoot, "dist", "cli.js");
+
+if (existsSync(localCli)) {
+  const result = spawnSync(process.execPath, [localCli, ...args], {
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 1);
+} else {
+  const result = spawnSync("npx", ["--yes", "diff-coverage", ...args], {
+    stdio: "inherit",
+    shell: true,
+  });
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
Adds a project-level skill at .claude/skills/diff-coverage/SKILL.md that
teaches Claude how to invoke the CLI using node with ${CLAUDE_SKILL_DIR}
for machine-agnostic absolute path resolution.

https://claude.ai/code/session_01NGWQG6BKWTGvoqfbtQwumg