### PR TITLE
add coverage exclusion patterns via glob and config file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import {
   formatResult,
   formatTypecheckResult,
   getDiffFiles,
+  loadConfig,
   runCoverage,
   runTypecheck,
 } from "./core.js";
@@ -14,6 +15,7 @@ type MeasureOpts = {
   base: string;
   cmd?: string;
   diffOnly: boolean;
+  exclude: string[];
   json: boolean;
   threshold?: number;
 };
@@ -24,7 +26,13 @@ async function measureFiles(
   extensions: string[],
   runner: RunnerType,
 ): Promise<void> {
-  const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
+  const diffFiles = await getDiffFiles(
+    cwd,
+    opts.base,
+    extensions,
+    undefined,
+    opts.exclude,
+  );
 
   if (diffFiles.length === 0) {
     console.log("No changed source files found.");
@@ -96,6 +104,10 @@ program
   )
   .option("--json", "Output raw JSON")
   .option("--diff-only", "Only show diff files, don't run tests")
+  .option(
+    "--exclude <patterns>",
+    "Comma-separated glob patterns to exclude files (e.g. '*.mocks.ts,src/fixtures/**')",
+  )
   .action(async (opts) => {
     const cwd = resolve(opts.cwd);
     const extensions = opts.ext.split(",").map((e: string) => e.trim());
@@ -107,11 +119,19 @@ program
     );
 
     try {
+      const config = await loadConfig(cwd);
+      const exclude = [
+        ...(config.exclude ?? []),
+        ...(opts.exclude
+          ? opts.exclude.split(",").map((e: string) => e.trim())
+          : []),
+      ];
       await measureFiles(
         {
           base: opts.base,
           cmd: opts.cmd,
           diffOnly: opts.diffOnly,
+          exclude,
           json: opts.json,
           threshold: opts.threshold,
         },
@@ -135,11 +155,29 @@ program
     "Comma-separated file extensions",
     "ts,tsx,js,jsx",
   )
+  .option(
+    "--exclude <patterns>",
+    "Comma-separated glob patterns to exclude files (e.g. '*.mocks.ts,src/fixtures/**')",
+  )
   .action(async (opts) => {
     const cwd = resolve(opts.cwd);
     const extensions = opts.ext.split(",").map((e: string) => e.trim());
 
-    const files = await getDiffFiles(cwd, opts.base, extensions);
+    const config = await loadConfig(cwd);
+    const exclude = [
+      ...(config.exclude ?? []),
+      ...(opts.exclude
+        ? opts.exclude.split(",").map((e: string) => e.trim())
+        : []),
+    ];
+
+    const files = await getDiffFiles(
+      cwd,
+      opts.base,
+      extensions,
+      undefined,
+      exclude,
+    );
     if (files.length === 0) {
       console.log("No changed source files.");
       return;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from "node:fs/promises";
+import { globToRegex, loadConfig } from "./core.js";
+
+const mockReadFile = vi.mocked(readFile);
+
+describe("loadConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty config when no config file exists", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
+    const config = await loadConfig("/project");
+    expect(config).toEqual({});
+  });
+
+  it("returns empty config when config file is malformed JSON", async () => {
+    mockReadFile.mockResolvedValueOnce("not json" as never);
+    const config = await loadConfig("/project");
+    expect(config).toEqual({});
+  });
+
+  it("loads exclude patterns from config file", async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ exclude: ["*.mocks.ts", "src/fixtures/**"] }) as never,
+    );
+    const config = await loadConfig("/project");
+    expect(config.exclude).toEqual(["*.mocks.ts", "src/fixtures/**"]);
+  });
+
+  it("returns empty config when exclude is not present", async () => {
+    mockReadFile.mockResolvedValueOnce(JSON.stringify({}) as never);
+    const config = await loadConfig("/project");
+    expect(config).toEqual({});
+  });
+
+  it("reads .diff-coverage.json from the given cwd", async () => {
+    mockReadFile.mockResolvedValueOnce(JSON.stringify({}) as never);
+    await loadConfig("/my/project");
+    expect(mockReadFile).toHaveBeenCalledWith(
+      "/my/project/.diff-coverage.json",
+      "utf-8",
+    );
+  });
+});
+
+describe("globToRegex", () => {
+  it("matches filename with * anywhere in path", () => {
+    const re = new RegExp(globToRegex("*.mocks.ts"));
+    expect(re.test("src/foo.mocks.ts")).toBe(true);
+    expect(re.test("foo.mocks.ts")).toBe(true);
+    expect(re.test("src/deep/foo.mocks.ts")).toBe(true);
+  });
+
+  it("does not match different extensions with *", () => {
+    const re = new RegExp(globToRegex("*.mocks.ts"));
+    expect(re.test("src/foo.test.ts")).toBe(false);
+    expect(re.test("src/foo.mocks.js")).toBe(false);
+  });
+
+  it("does not match across path separators with *", () => {
+    const re = new RegExp(globToRegex("*.ts"));
+    expect(re.test("src/foo.ts")).toBe(true);
+    // * alone should not match a full path like src/foo — but it should match filenames
+    expect(re.test("src/sub/bar.ts")).toBe(true);
+  });
+
+  it("matches zero or more path segments with **/ prefix", () => {
+    const re = new RegExp(globToRegex("**/*.mocks.ts"));
+    expect(re.test("foo.mocks.ts")).toBe(true);
+    expect(re.test("src/foo.mocks.ts")).toBe(true);
+    expect(re.test("src/utils/foo.mocks.ts")).toBe(true);
+  });
+
+  it("anchors patterns containing slash to the start of the path", () => {
+    const re = new RegExp(globToRegex("src/*.mocks.ts"));
+    expect(re.test("src/foo.mocks.ts")).toBe(true);
+    expect(re.test("other/foo.mocks.ts")).toBe(false);
+    expect(re.test("other/src/foo.mocks.ts")).toBe(false);
+  });
+
+  it("matches any file under a directory with src/**", () => {
+    const re = new RegExp(globToRegex("src/**"));
+    expect(re.test("src/foo.ts")).toBe(true);
+    expect(re.test("src/utils/bar.ts")).toBe(true);
+    expect(re.test("other/foo.ts")).toBe(false);
+  });
+
+  it("matches files with intermediate directories using src/**/file", () => {
+    const re = new RegExp(globToRegex("src/**/*.mocks.ts"));
+    expect(re.test("src/foo.mocks.ts")).toBe(true);
+    expect(re.test("src/utils/foo.mocks.ts")).toBe(true);
+    expect(re.test("src/a/b/foo.mocks.ts")).toBe(true);
+    expect(re.test("other/foo.mocks.ts")).toBe(false);
+  });
+
+  it("matches single character with ?", () => {
+    const re = new RegExp(globToRegex("foo?.ts"));
+    expect(re.test("src/fooa.ts")).toBe(true);
+    expect(re.test("src/foo.ts")).toBe(false);
+  });
+});

--- a/src/core.ts
+++ b/src/core.ts
@@ -39,11 +39,16 @@ export type DiffCoverageResult = {
 export type RunOptions = {
   base?: string;
   cwd: string;
+  exclude?: string[];
   excludePatterns?: string[];
   extensions?: string[];
   runner?: RunnerType | "auto";
   testCommand?: string;
   threshold?: number;
+};
+
+export type DiffCoverageConfig = {
+  exclude?: string[];
 };
 
 // Istanbul/V8 coverage file format
@@ -89,6 +94,27 @@ const DEFAULT_EXCLUDE = [
   "/coverage/",
 ];
 
+// ─── Glob / config helpers ───────────────────────────────────────────────────
+
+export const globToRegex = (glob: string): string => {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\?/g, "[^/]")
+    .split("**/")
+    .map((seg) => seg.split("**").join(".*").split("*").join("[^/]*"))
+    .join("(.*/)?");
+  return glob.includes("/") ? `^${escaped}($|/)` : `(^|/)${escaped}$`;
+};
+
+export const loadConfig = async (cwd: string): Promise<DiffCoverageConfig> => {
+  try {
+    const raw = await readFile(resolve(cwd, ".diff-coverage.json"), "utf-8");
+    return JSON.parse(raw) as DiffCoverageConfig;
+  } catch {
+    return {};
+  }
+};
+
 // ─── Git diff helpers ────────────────────────────────────────────────────────
 
 export async function getDiffFiles(
@@ -96,8 +122,10 @@ export async function getDiffFiles(
   base = "main",
   extensions = DEFAULT_EXTENSIONS,
   excludePatterns = DEFAULT_EXCLUDE,
+  exclude: string[] = [],
 ): Promise<DiffFile[]> {
   const extPattern = extensions.join("|");
+  const allExcludePatterns = [...excludePatterns, ...exclude.map(globToRegex)];
 
   let baseRef = base;
   try {
@@ -125,7 +153,7 @@ export async function getDiffFiles(
     .split("\n")
     .filter(Boolean)
     .filter((f) => new RegExp(`\\.(${extPattern})$`).test(f))
-    .filter((f) => !excludePatterns.some((p) => new RegExp(p).test(f)));
+    .filter((f) => !allExcludePatterns.some((p) => new RegExp(p).test(f)));
 
   if (allFiles.length === 0) return [];
 

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -188,6 +188,57 @@ describe("getDiffFiles", () => {
     expect(files[0].addedLines).toEqual([]);
   });
 
+  it("filters out files matching a glob exclude pattern", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "/project" },
+      { stdout: "src/foo.ts\nsrc/foo.mocks.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main", undefined, undefined, [
+      "*.mocks.ts",
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("filters out files matching a path-anchored glob exclude pattern", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "/project" },
+      { stdout: "src/fixtures/data.ts\nsrc/foo.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main", undefined, undefined, [
+      "src/fixtures/**",
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
+  it("combines default regex excludes with glob excludes", async () => {
+    mockGit(
+      new Error("no origin"),
+      { stdout: "/project" },
+      { stdout: "src/foo.ts\nsrc/foo.mocks.ts\nsrc/foo.test.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project", "main", undefined, undefined, [
+      "*.mocks.ts",
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("src/foo.ts");
+  });
+
   it("handles multiple changed files", async () => {
     mockGit(
       new Error("no origin"),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -8,6 +8,7 @@ import {
   type FileDetail,
   formatResult,
   getDiffFiles,
+  loadConfig,
   runCoverage,
 } from "./core.js";
 import { detectRunner } from "./runner/detect.js";
@@ -79,6 +80,12 @@ server.tool(
       .describe(
         "Absolute path to the project root (where package.json and test config live)",
       ),
+    exclude: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Glob patterns for files to exclude from coverage (e.g. ['*.mocks.ts', 'src/fixtures/**'])",
+      ),
     extensions: z
       .array(z.string())
       .optional()
@@ -97,11 +104,27 @@ server.tool(
         "Minimum line coverage % — result is marked as error if below this",
       ),
   },
-  async ({ cwd, base, runner, testCommand, extensions, threshold }) => {
+  async ({
+    cwd,
+    base,
+    runner,
+    testCommand,
+    extensions,
+    exclude,
+    threshold,
+  }) => {
     const absPath = resolve(cwd);
 
     try {
-      const diffFiles = await getDiffFiles(absPath, base, extensions);
+      const config = await loadConfig(absPath);
+      const mergedExclude = [...(config.exclude ?? []), ...(exclude ?? [])];
+      const diffFiles = await getDiffFiles(
+        absPath,
+        base,
+        extensions,
+        undefined,
+        mergedExclude,
+      );
 
       if (diffFiles.length === 0) {
         return {
@@ -156,11 +179,24 @@ server.tool(
       .default("main")
       .describe("Base branch to diff against"),
     cwd: z.string().describe("Absolute path to the project root"),
+    exclude: z
+      .array(z.string())
+      .optional()
+      .describe("Glob patterns for files to exclude (e.g. ['*.mocks.ts'])"),
     extensions: z.array(z.string()).optional(),
   },
-  async ({ cwd, base, extensions }) => {
+  async ({ cwd, base, extensions, exclude }) => {
     try {
-      const files = await getDiffFiles(resolve(cwd), base, extensions);
+      const absPath = resolve(cwd);
+      const config = await loadConfig(absPath);
+      const mergedExclude = [...(config.exclude ?? []), ...(exclude ?? [])];
+      const files = await getDiffFiles(
+        absPath,
+        base,
+        extensions,
+        undefined,
+        mergedExclude,
+      );
 
       if (files.length === 0) {
         return {


### PR DESCRIPTION
- Add `globToRegex` helper that converts glob patterns (*, **, ?) to regex
- Add `loadConfig` that reads exclude patterns from `.diff-coverage.json`
- Add `exclude` parameter to `getDiffFiles` for user-facing glob patterns
- Add `--exclude` option to CLI `measure` and `diff` commands (comma-separated globs)
- Add `exclude` parameter to MCP tools `measure_diff_coverage` and `get_diff_files`
- Config file patterns and CLI patterns are merged at runtime
- Add tests for `globToRegex`, `loadConfig`, and `getDiffFiles` glob exclusion

https://claude.ai/code/session_01A4nZZBsbY2QNrMmMxWkX5Q