### PR TITLE
add test practices rule and refactor tests with it.each

### DIFF
--- a/.claude/rules/shared/test.md
+++ b/.claude/rules/shared/test.md
@@ -1,0 +1,249 @@
+---
+applyTo: '**/*.test.{ts,tsx}'
+paths:
+  - '**/*.test.{ts,tsx}'
+---
+
+# テストコードのコーディングガイドライン
+
+このリポジトリでは Vitest を使ってテストを記述します。
+コードレビュー時は以下のルールに基づいて指摘してください。
+
+## 重複した入出力ケースは `it.each` でデータ駆動化する
+
+「同じ関数を呼んで、入力と期待結果だけが違う」テストを `it` で並べると、
+本質的な差分（入力と出力の対応）が assertion 周辺の定型コードに埋もれます。
+このようなケースは `it.each` でテーブルにまとめ、
+「入力 → 期待結果」の対応が一目で読めるようにしてください。
+
+### タプル形式（引数が少ないとき）
+
+```ts
+// Good: しきい値と icon の対応がテーブルで一覧できる
+it.each([
+  [80, "✅"],
+  [100, "✅"],
+  [50, "⚠️"],
+  [79, "⚠️"],
+  [0, "❌"],
+  [49, "❌"],
+])("renders %s%% coverage with %s icon", (pct, icon) => {
+  expect(formatResult(resultWithFile("src/a.ts", pct))).toContain(icon);
+});
+
+// Bad: 同じ assertion を 3 回コピペしていて、しきい値の境界が読み取りにくい
+it("uses ✅ icon for coverage >= 80%", () => {
+  expect(formatResult(resultWithFile("src/a.ts", 80))).toContain("✅");
+  expect(formatResult(resultWithFile("src/a.ts", 100))).toContain("✅");
+});
+it("uses ⚠️ icon for coverage >= 50% and < 80%", () => {
+  expect(formatResult(resultWithFile("src/a.ts", 50))).toContain("⚠️");
+  expect(formatResult(resultWithFile("src/a.ts", 79))).toContain("⚠️");
+});
+it("uses ❌ icon for coverage < 50%", () => {
+  expect(formatResult(resultWithFile("src/a.ts", 0))).toContain("❌");
+  expect(formatResult(resultWithFile("src/a.ts", 49))).toContain("❌");
+});
+```
+
+### オブジェクト形式（引数が多いとき）
+
+引数が 3 つ以上、または意味が名前から分からないときは
+オブジェクト形式にして `$propName` でテスト名にプロパティを差し込んでください。
+
+```ts
+// Good: 各ケースの意図が name から読める
+it.each([
+  { name: "matches *.mocks.ts under any directory", pattern: "*.mocks.ts", input: "src/foo.mocks.ts", expected: true },
+  { name: "rejects different extension", pattern: "*.mocks.ts", input: "src/foo.test.ts", expected: false },
+  { name: "anchors path-with-slash patterns to start", pattern: "src/*.mocks.ts", input: "other/foo.mocks.ts", expected: false },
+])("$name", ({ pattern, input, expected }) => {
+  expect(new RegExp(globToRegex(pattern)).test(input)).toBe(expected);
+});
+
+// Bad: タプルの 3 列目が boolean だが、何が「true」なのか名前から分からない
+it.each([
+  ["*.mocks.ts", "src/foo.mocks.ts", true],
+  ["*.mocks.ts", "src/foo.test.ts", false],
+])("globToRegex %s vs %s", (pattern, input, expected) => { ... });
+```
+
+## モックの前提が複数の観点で検証されるなら `describe.each` でスイートを括る
+
+「同じセットアップで、複数の `it` を流したい」ときは `describe.each` でまとめます。
+1 ケースに対して `it` 1 個（=観点 1 個）に絞れるので、失敗時にどの観点が壊れたか即座に分かります。
+
+```ts
+// Good: 同じ vitest config 配置 → runner detect の各観点を別々の it で検証
+describe.each([
+  { filename: "vitest.config.ts", content: "export default {}" },
+  { filename: "vitest.config.js", content: "module.exports = {}" },
+  { filename: "vitest.config.mts", content: "export default {}" },
+])("detectRunner with $filename", ({ filename, content }) => {
+  it("returns 'vitest'", async () => {
+    await writeFile(join(tmpDir, filename), content);
+    expect(await detectRunner(tmpDir)).toBe("vitest");
+  });
+});
+```
+
+`it.each` と `describe.each` の使い分けはシンプルに:
+
+- 検証が assertion 1 行 → `it.each`
+- 同じ前提から複数観点を検証 → `describe.each`
+
+## テストデータは Builder / Factory 関数で組み立てる
+
+巨大なオブジェクトをテスト本体にインラインで書くと、「このテストで本質的に違う部分はどこか」が読み取れなくなります。
+共通部分はファイル先頭の factory 関数に追い出し、`Partial<T>` のオーバーライドだけテスト本体に書いてください。
+
+```ts
+// Good: デフォルト値は factory に押し込み、テスト本体は「差分」だけが残る
+function makeResult(overrides?: Partial<DiffCoverageResult>): DiffCoverageResult {
+  return {
+    files: [],
+    runner: "jest",
+    summary: { /* ... */ },
+    timestamp: "2024-01-01T00:00:00.000Z",
+    uncoveredFiles: [],
+    ...overrides,
+  };
+}
+
+it("includes runner name in header", () => {
+  expect(formatResult(makeResult({ runner: "vitest" }))).toContain("vitest");
+});
+
+// Bad: テストごとに完全なオブジェクトを書いていて、何が変わっているか目視で diff を取る必要がある
+it("includes runner name in header", () => {
+  const result: DiffCoverageResult = {
+    files: [],
+    runner: "vitest",
+    summary: { /* 同じ巨大なオブジェクト */ },
+    timestamp: "2024-01-01T00:00:00.000Z",
+    uncoveredFiles: [],
+  };
+  expect(formatResult(result)).toContain("vitest");
+});
+```
+
+## `describe` は対象、`it` は振る舞いで命名する
+
+- `describe` には「何をテストしているか」（関数名・クラス名）を書きます
+- `it` には「どう振る舞うか」を `〜する` / `returns 〜` の形で書きます
+- ケースの内容を細かく書くより、「入力 → 期待結果」の対応が短く分かる名前を優先してください
+
+```ts
+// Good
+describe("getDiffFiles", () => {
+  it("returns empty array when git diff reports no changed files", async () => { ... });
+  it("filters out test files by default", async () => { ... });
+});
+
+// Bad: describe / it の責務が逆転している、または冗長
+describe("test for the function that gets diff files from git", () => {
+  it("getDiffFiles", async () => { ... });
+});
+```
+
+## モックは毎テスト前にリセットする
+
+`vi.fn()` の呼び出し履歴やオーバーライドはテスト間で共有されます。
+リークを避けるため、モックを使う `describe` の冒頭で `beforeEach(() => vi.clearAllMocks())` を呼んでください。
+連続呼び出しのスタブには `mockResolvedValueOnce` / `mockRejectedValueOnce` を使い、
+1 回ごとの応答を明示します。
+
+```ts
+// Good: clearAllMocks で履歴を毎回リセットし、Once 系で順序を明示
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it("falls back when origin/<base> is missing", async () => {
+  mockExeca
+    .mockRejectedValueOnce(new Error("no origin/main")) // git rev-parse --verify
+    .mockResolvedValueOnce({ stdout: "/project" } as never); // git rev-parse --show-toplevel
+  await getDiffFiles("/project", "main");
+});
+
+// Bad: clearAllMocks を忘れていて、前のテストの呼び出しが mock.calls に残る
+it("falls back when origin/<base> is missing", async () => {
+  mockExeca.mockResolvedValue({ stdout: "/project" } as never); // 全呼び出しに同じ値が返る
+  ...
+});
+```
+
+連続スタブの繰り返しが多い場合は、ヘルパ関数（例: `mockGit(...returns)`）に切り出して
+テスト本体から定型処理を消してください。
+
+## ファイルシステム等の副作用フィクスチャは afterEach で必ず片付ける
+
+`mkdtemp` で作った一時ディレクトリ、書き込んだファイル、起動したプロセスは
+テストが落ちた場合でも残らないよう、`afterEach` で確実に解放します。
+
+```ts
+// Good: tmpDir は afterEach で必ず削除される
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "my-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { force: true, recursive: true });
+});
+
+// Bad: テスト本体の最後で削除しているため、assertion が落ちると残骸が残る
+it("does something with a tmp dir", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "my-test-"));
+  // ... assertion が途中で落ちると次の行に到達しない
+  await rm(tmpDir, { force: true, recursive: true });
+});
+```
+
+## アサーションは「何を検証したいか」で粒度を選ぶ
+
+- 完全な等価検証: `toEqual`（ディープ）/ `toBe`（参照・プリミティブ）
+- 部分一致: `toContain`（配列・文字列）/ `toMatchObject`（オブジェクト部分一致）
+- モック呼び出し: `toHaveBeenCalledWith` / `toHaveBeenCalledOnce`
+- 例外: `toThrow` / 非同期は `await expect(promise).rejects.toThrow(...)`
+
+意図と粒度がズレた matcher を使うと、
+- 過剰に厳しい assertion で関係ない変更で壊れる
+- 過剰に緩い assertion で本来検出したいリグレッションが通ってしまう
+
+```ts
+// Good: 「runner 名がヘッダに入っていること」だけを検証 → toContain
+expect(formatResult(makeResult({ runner: "vitest" }))).toContain("vitest");
+
+// Good: 「diff ファイルが正確にこの 1 件であること」を検証 → toEqual
+expect(files).toEqual([
+  { addedLines: [1, 2, 3], additions: 3, deletions: 0, path: "src/foo.ts" },
+]);
+
+// Bad: 「含まれていれば OK」程度の検証なのに完全一致を要求している
+expect(formatResult(makeResult({ runner: "vitest" }))).toBe(
+  "Header: vitest\n...完全な出力文字列...",
+);
+```
+
+## 非同期テストは `async` / `await` で書く
+
+`typescript.md` のルールに整合させ、テストでも Promise チェーンや `done` コールバックは使いません。
+失敗パスは `await expect(...).rejects.toThrow(...)` で検証します。
+
+```ts
+// Good: async/await で素直に書く
+it("rejects when ref is missing", async () => {
+  await expect(resolveRef("/repo", "missing")).rejects.toThrow(/not found/);
+});
+
+// Bad: .then().catch() で失敗時の done を忘れる典型パターン
+it("rejects when ref is missing", () => {
+  return resolveRef("/repo", "missing").then(() => {
+    throw new Error("should have thrown");
+  }, (err) => {
+    expect(err.message).toMatch(/not found/);
+  });
+});
+```

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -14,16 +14,23 @@ describe("loadConfig", () => {
     vi.clearAllMocks();
   });
 
-  it("returns empty config when no config file exists", async () => {
-    mockReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-    const config = await loadConfig("/project");
-    expect(config).toEqual({});
-  });
-
-  it("returns empty config when config file is malformed JSON", async () => {
-    mockReadFile.mockResolvedValueOnce("not json" as never);
-    const config = await loadConfig("/project");
-    expect(config).toEqual({});
+  it.each([
+    {
+      name: "no config file exists",
+      setup: () => mockReadFile.mockRejectedValueOnce(new Error("ENOENT")),
+    },
+    {
+      name: "config file is malformed JSON",
+      setup: () => mockReadFile.mockResolvedValueOnce("not json" as never),
+    },
+    {
+      name: "exclude is not present",
+      setup: () =>
+        mockReadFile.mockResolvedValueOnce(JSON.stringify({}) as never),
+    },
+  ])("returns empty config when $name", async ({ setup }) => {
+    setup();
+    expect(await loadConfig("/project")).toEqual({});
   });
 
   it("loads exclude patterns from config file", async () => {
@@ -32,12 +39,6 @@ describe("loadConfig", () => {
     );
     const config = await loadConfig("/project");
     expect(config.exclude).toEqual(["*.mocks.ts", "src/fixtures/**"]);
-  });
-
-  it("returns empty config when exclude is not present", async () => {
-    mockReadFile.mockResolvedValueOnce(JSON.stringify({}) as never);
-    const config = await loadConfig("/project");
-    expect(config).toEqual({});
   });
 
   it("reads .diff-coverage.json from the given cwd", async () => {
@@ -51,58 +52,140 @@ describe("loadConfig", () => {
 });
 
 describe("globToRegex", () => {
-  it("matches filename with * anywhere in path", () => {
-    const re = new RegExp(globToRegex("*.mocks.ts"));
-    expect(re.test("src/foo.mocks.ts")).toBe(true);
-    expect(re.test("foo.mocks.ts")).toBe(true);
-    expect(re.test("src/deep/foo.mocks.ts")).toBe(true);
-  });
-
-  it("does not match different extensions with *", () => {
-    const re = new RegExp(globToRegex("*.mocks.ts"));
-    expect(re.test("src/foo.test.ts")).toBe(false);
-    expect(re.test("src/foo.mocks.js")).toBe(false);
-  });
-
-  it("does not match across path separators with *", () => {
-    const re = new RegExp(globToRegex("*.ts"));
-    expect(re.test("src/foo.ts")).toBe(true);
-    // * alone should not match a full path like src/foo — but it should match filenames
-    expect(re.test("src/sub/bar.ts")).toBe(true);
-  });
-
-  it("matches zero or more path segments with **/ prefix", () => {
-    const re = new RegExp(globToRegex("**/*.mocks.ts"));
-    expect(re.test("foo.mocks.ts")).toBe(true);
-    expect(re.test("src/foo.mocks.ts")).toBe(true);
-    expect(re.test("src/utils/foo.mocks.ts")).toBe(true);
-  });
-
-  it("anchors patterns containing slash to the start of the path", () => {
-    const re = new RegExp(globToRegex("src/*.mocks.ts"));
-    expect(re.test("src/foo.mocks.ts")).toBe(true);
-    expect(re.test("other/foo.mocks.ts")).toBe(false);
-    expect(re.test("other/src/foo.mocks.ts")).toBe(false);
-  });
-
-  it("matches any file under a directory with src/**", () => {
-    const re = new RegExp(globToRegex("src/**"));
-    expect(re.test("src/foo.ts")).toBe(true);
-    expect(re.test("src/utils/bar.ts")).toBe(true);
-    expect(re.test("other/foo.ts")).toBe(false);
-  });
-
-  it("matches files with intermediate directories using src/**/file", () => {
-    const re = new RegExp(globToRegex("src/**/*.mocks.ts"));
-    expect(re.test("src/foo.mocks.ts")).toBe(true);
-    expect(re.test("src/utils/foo.mocks.ts")).toBe(true);
-    expect(re.test("src/a/b/foo.mocks.ts")).toBe(true);
-    expect(re.test("other/foo.mocks.ts")).toBe(false);
-  });
-
-  it("matches single character with ?", () => {
-    const re = new RegExp(globToRegex("foo?.ts"));
-    expect(re.test("src/fooa.ts")).toBe(true);
-    expect(re.test("src/foo.ts")).toBe(false);
+  it.each([
+    {
+      expected: true,
+      input: "src/foo.mocks.ts",
+      name: "matches filename with * anywhere in path",
+      pattern: "*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "foo.mocks.ts",
+      name: "matches root-level filename with *",
+      pattern: "*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/deep/foo.mocks.ts",
+      name: "matches deeply nested filename with *",
+      pattern: "*.mocks.ts",
+    },
+    {
+      expected: false,
+      input: "src/foo.test.ts",
+      name: "does not match different file suffix",
+      pattern: "*.mocks.ts",
+    },
+    {
+      expected: false,
+      input: "src/foo.mocks.js",
+      name: "does not match different extension",
+      pattern: "*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/foo.ts",
+      name: "matches at root with *",
+      pattern: "*.ts",
+    },
+    {
+      expected: true,
+      input: "src/sub/bar.ts",
+      name: "matches nested file with *",
+      pattern: "*.ts",
+    },
+    {
+      expected: true,
+      input: "foo.mocks.ts",
+      name: "matches root-level filename with **/ prefix",
+      pattern: "**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/foo.mocks.ts",
+      name: "matches one-segment-deep filename with **/ prefix",
+      pattern: "**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/utils/foo.mocks.ts",
+      name: "matches multi-segment-deep filename with **/ prefix",
+      pattern: "**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/foo.mocks.ts",
+      name: "matches when slash-anchored pattern starts at root",
+      pattern: "src/*.mocks.ts",
+    },
+    {
+      expected: false,
+      input: "other/foo.mocks.ts",
+      name: "rejects when slash-anchored pattern misses root prefix",
+      pattern: "src/*.mocks.ts",
+    },
+    {
+      expected: false,
+      input: "other/src/foo.mocks.ts",
+      name: "rejects when slash-anchored pattern is shifted into a subdir",
+      pattern: "src/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/foo.ts",
+      name: "matches direct child with dir/**",
+      pattern: "src/**",
+    },
+    {
+      expected: true,
+      input: "src/utils/bar.ts",
+      name: "matches deep descendant with dir/**",
+      pattern: "src/**",
+    },
+    {
+      expected: false,
+      input: "other/foo.ts",
+      name: "rejects sibling directory with dir/**",
+      pattern: "src/**",
+    },
+    {
+      expected: true,
+      input: "src/foo.mocks.ts",
+      name: "matches direct child with dir/**/file",
+      pattern: "src/**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/utils/foo.mocks.ts",
+      name: "matches one-deep child with dir/**/file",
+      pattern: "src/**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/a/b/foo.mocks.ts",
+      name: "matches two-deep child with dir/**/file",
+      pattern: "src/**/*.mocks.ts",
+    },
+    {
+      expected: false,
+      input: "other/foo.mocks.ts",
+      name: "rejects sibling directory with dir/**/file",
+      pattern: "src/**/*.mocks.ts",
+    },
+    {
+      expected: true,
+      input: "src/fooa.ts",
+      name: "matches single character with ?",
+      pattern: "foo?.ts",
+    },
+    {
+      expected: false,
+      input: "src/foo.ts",
+      name: "rejects when ? has no character to match",
+      pattern: "foo?.ts",
+    },
+  ])("$name", ({ pattern, input, expected }) => {
+    expect(new RegExp(globToRegex(pattern)).test(input)).toBe(expected);
   });
 });

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -99,61 +99,69 @@ describe("getDiffFiles", () => {
     expect(files[0].addedLines).toContain(21);
   });
 
-  it("filters out test files by default", async () => {
+  it.each([
+    {
+      changedFiles: "src/foo.ts\nsrc/foo.test.ts\nsrc/foo.spec.ts",
+      excludeGlobs: undefined,
+      extensions: undefined,
+      name: "test files (.test.ts / .spec.ts) by default",
+    },
+    {
+      changedFiles: "src/foo.ts\nlib/node_modules/pkg/index.ts",
+      excludeGlobs: undefined,
+      extensions: undefined,
+      name: "files inside a node_modules subdirectory",
+    },
+    {
+      changedFiles: "src/foo.ts\nsrc/types.d.ts",
+      excludeGlobs: undefined,
+      extensions: undefined,
+      name: ".d.ts declaration files",
+    },
+    {
+      changedFiles: "src/foo.ts",
+      excludeGlobs: undefined,
+      extensions: ["ts"] as string[],
+      name: "files not matching the provided extension allow-list",
+    },
+    {
+      changedFiles: "src/foo.ts\nsrc/foo.mocks.ts",
+      excludeGlobs: ["*.mocks.ts"] as string[],
+      extensions: undefined,
+      name: "files matching a glob exclude pattern",
+    },
+    {
+      changedFiles: "src/fixtures/data.ts\nsrc/foo.ts",
+      excludeGlobs: ["src/fixtures/**"] as string[],
+      extensions: undefined,
+      name: "files matching a path-anchored glob exclude pattern",
+    },
+    {
+      changedFiles: "src/foo.ts\nsrc/foo.mocks.ts\nsrc/foo.test.ts",
+      excludeGlobs: ["*.mocks.ts"] as string[],
+      extensions: undefined,
+      name: "default regex excludes alongside provided glob excludes",
+    },
+  ])("filters out $name and keeps src/foo.ts", async ({
+    changedFiles,
+    extensions,
+    excludeGlobs,
+  }) => {
     mockGit(
       new Error("no origin"),
       { stdout: "/project" },
-      { stdout: "src/foo.ts\nsrc/foo.test.ts\nsrc/foo.spec.ts" },
+      { stdout: changedFiles },
       { stdout: "1\t0\tsrc/foo.ts" },
       { stdout: "" },
     );
 
-    const files = await getDiffFiles("/project", "main");
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
-  });
-
-  it("filters out files inside a node_modules subdirectory", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/foo.ts\nlib/node_modules/pkg/index.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
+    const files = await getDiffFiles(
+      "/project",
+      "main",
+      extensions,
+      undefined,
+      excludeGlobs,
     );
-
-    const files = await getDiffFiles("/project", "main");
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
-  });
-
-  it("filters out .d.ts declaration files", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/foo.ts\nsrc/types.d.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
-    );
-
-    const files = await getDiffFiles("/project", "main");
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
-  });
-
-  it("filters files by provided extensions", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/foo.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
-    );
-
-    const files = await getDiffFiles("/project", "main", ["ts"]);
 
     expect(files).toHaveLength(1);
     expect(files[0].path).toBe("src/foo.ts");
@@ -186,57 +194,6 @@ describe("getDiffFiles", () => {
     const files = await getDiffFiles("/project", "main");
 
     expect(files[0].addedLines).toEqual([]);
-  });
-
-  it("filters out files matching a glob exclude pattern", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/foo.ts\nsrc/foo.mocks.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
-    );
-
-    const files = await getDiffFiles("/project", "main", undefined, undefined, [
-      "*.mocks.ts",
-    ]);
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
-  });
-
-  it("filters out files matching a path-anchored glob exclude pattern", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/fixtures/data.ts\nsrc/foo.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
-    );
-
-    const files = await getDiffFiles("/project", "main", undefined, undefined, [
-      "src/fixtures/**",
-    ]);
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
-  });
-
-  it("combines default regex excludes with glob excludes", async () => {
-    mockGit(
-      new Error("no origin"),
-      { stdout: "/project" },
-      { stdout: "src/foo.ts\nsrc/foo.mocks.ts\nsrc/foo.test.ts" },
-      { stdout: "1\t0\tsrc/foo.ts" },
-      { stdout: "" },
-    );
-
-    const files = await getDiffFiles("/project", "main", undefined, undefined, [
-      "*.mocks.ts",
-    ]);
-
-    expect(files).toHaveLength(1);
-    expect(files[0].path).toBe("src/foo.ts");
   });
 
   it("handles multiple changed files", async () => {

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -79,29 +79,27 @@ describe("formatResult", () => {
     expect(out).toContain("src/foo.ts");
   });
 
-  it("uses ✅ icon for coverage >= 80%", () => {
-    expect(formatResult(resultWithFile("src/a.ts", 80))).toContain("✅");
-    expect(formatResult(resultWithFile("src/a.ts", 100))).toContain("✅");
+  it.each([
+    [100, "✅"],
+    [80, "✅"],
+    [79, "⚠️"],
+    [50, "⚠️"],
+    [49, "❌"],
+    [0, "❌"],
+  ])("renders %d%% coverage with %s icon", (pct, icon) => {
+    expect(formatResult(resultWithFile("src/a.ts", pct))).toContain(icon);
   });
 
-  it("uses ⚠️ icon for coverage >= 50% and < 80%", () => {
-    expect(formatResult(resultWithFile("src/a.ts", 50))).toContain("⚠️");
-    expect(formatResult(resultWithFile("src/a.ts", 79))).toContain("⚠️");
-  });
-
-  it("uses ❌ icon for coverage < 50%", () => {
-    expect(formatResult(resultWithFile("src/a.ts", 0))).toContain("❌");
-    expect(formatResult(resultWithFile("src/a.ts", 49))).toContain("❌");
-  });
-
-  it("shows PASS when line coverage meets threshold", () => {
-    const out = formatResult(resultWithFile("src/a.ts", 80), 80);
-    expect(out).toContain("✅ PASS");
-  });
-
-  it("shows FAIL when line coverage is below threshold", () => {
-    const out = formatResult(resultWithFile("src/a.ts", 60), 80);
-    expect(out).toContain("❌ FAIL");
+  it.each([
+    { expected: "✅ PASS", pct: 80, threshold: 80 },
+    { expected: "❌ FAIL", pct: 60, threshold: 80 },
+  ])("shows $expected when coverage is $pct% against threshold $threshold%", ({
+    pct,
+    threshold,
+    expected,
+  }) => {
+    const out = formatResult(resultWithFile("src/a.ts", pct), threshold);
+    expect(out).toContain(expected);
   });
 
   it("does not show threshold line when threshold is not provided", () => {
@@ -144,97 +142,77 @@ describe("formatTypecheckResult", () => {
     };
   }
 
+  function passingTypecheckResult(): TypecheckResult {
+    return makeTypecheckResult({
+      diffFiles: ["src/foo.ts"],
+      files: [{ errors: [], path: "src/foo.ts" }],
+      passed: true,
+      totalErrors: 0,
+    });
+  }
+
+  function failingTypecheckResult(): TypecheckResult {
+    return makeTypecheckResult({
+      diffFiles: ["src/foo.ts"],
+      files: [
+        {
+          errors: [
+            {
+              code: "TS2322",
+              column: 5,
+              file: "src/foo.ts",
+              line: 10,
+              message: "Type 'string' is not assignable to type 'number'.",
+            },
+          ],
+          path: "src/foo.ts",
+        },
+      ],
+      passed: false,
+      totalErrors: 1,
+    });
+  }
+
   it("shows no-files message when files list is empty", () => {
     const out = formatTypecheckResult(makeTypecheckResult());
     expect(out).toContain("No changed TypeScript files found");
   });
 
-  it("shows file count and error count", () => {
-    const out = formatTypecheckResult(
-      makeTypecheckResult({
-        diffFiles: ["src/foo.ts"],
-        files: [{ errors: [], path: "src/foo.ts" }],
-        passed: true,
-        totalErrors: 0,
-      }),
-    );
-    expect(out).toContain("Files checked: 1");
-    expect(out).toContain("Total errors: 0");
+  describe("with a passing result", () => {
+    it("shows file count and error count", () => {
+      const out = formatTypecheckResult(passingTypecheckResult());
+      expect(out).toContain("Files checked: 1");
+      expect(out).toContain("Total errors: 0");
+    });
+
+    it("shows PASS status", () => {
+      expect(formatTypecheckResult(passingTypecheckResult())).toContain(
+        "✅ PASS",
+      );
+    });
+
+    it("does not show error section", () => {
+      expect(formatTypecheckResult(passingTypecheckResult())).not.toContain(
+        "Errors by File",
+      );
+    });
   });
 
-  it("shows PASS status when no errors", () => {
-    const out = formatTypecheckResult(
-      makeTypecheckResult({
-        diffFiles: ["src/foo.ts"],
-        files: [{ errors: [], path: "src/foo.ts" }],
-        passed: true,
-        totalErrors: 0,
-      }),
-    );
-    expect(out).toContain("✅ PASS");
-  });
+  describe("with a failing result", () => {
+    it("shows FAIL status", () => {
+      expect(formatTypecheckResult(failingTypecheckResult())).toContain(
+        "❌ FAIL",
+      );
+    });
 
-  it("shows FAIL status when there are errors", () => {
-    const out = formatTypecheckResult(
-      makeTypecheckResult({
-        diffFiles: ["src/foo.ts"],
-        files: [
-          {
-            errors: [
-              {
-                code: "TS2322",
-                column: 5,
-                file: "src/foo.ts",
-                line: 10,
-                message: "Type 'string' is not assignable to type 'number'.",
-              },
-            ],
-            path: "src/foo.ts",
-          },
-        ],
-        passed: false,
-        totalErrors: 1,
-      }),
-    );
-    expect(out).toContain("❌ FAIL");
-  });
-
-  it("shows error details when errors exist", () => {
-    const out = formatTypecheckResult(
-      makeTypecheckResult({
-        diffFiles: ["src/foo.ts"],
-        files: [
-          {
-            errors: [
-              {
-                code: "TS2322",
-                column: 5,
-                file: "src/foo.ts",
-                line: 10,
-                message: "Type 'string' is not assignable to type 'number'.",
-              },
-            ],
-            path: "src/foo.ts",
-          },
-        ],
-        passed: false,
-        totalErrors: 1,
-      }),
-    );
-    expect(out).toContain("TS2322");
-    expect(out).toContain("10:5");
-    expect(out).toContain("src/foo.ts");
-  });
-
-  it("does not show error section when no errors", () => {
-    const out = formatTypecheckResult(
-      makeTypecheckResult({
-        diffFiles: ["src/foo.ts"],
-        files: [{ errors: [], path: "src/foo.ts" }],
-        passed: true,
-        totalErrors: 0,
-      }),
-    );
-    expect(out).not.toContain("Errors by File");
+    it.each([
+      ["TS2322"],
+      ["10:5"],
+      ["src/foo.ts"],
+    ])("shows error detail %s", (fragment) => {
+      expect(formatTypecheckResult(failingTypecheckResult())).toContain(
+        fragment,
+      );
+    });
   });
 });

--- a/src/runner/detect.test.ts
+++ b/src/runner/detect.test.ts
@@ -15,96 +15,80 @@ describe("detectRunner", () => {
     await rm(tmpDir, { force: true, recursive: true });
   });
 
-  it("detects vitest from vitest.config.ts", async () => {
-    await writeFile(join(tmpDir, "vitest.config.ts"), "export default {}");
+  it.each([
+    { content: "export default {}", filename: "vitest.config.ts" },
+    { content: "module.exports = {}", filename: "vitest.config.js" },
+    { content: "export default {}", filename: "vitest.config.mts" },
+  ])("detects vitest from $filename", async ({ filename, content }) => {
+    await writeFile(join(tmpDir, filename), content);
     expect(await detectRunner(tmpDir)).toBe("vitest");
   });
 
-  it("detects vitest from vitest.config.js", async () => {
-    await writeFile(join(tmpDir, "vitest.config.js"), "module.exports = {}");
-    expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("detects vitest from vitest.config.mts", async () => {
-    await writeFile(join(tmpDir, "vitest.config.mts"), "export default {}");
-    expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("detects vitest from vite.config.ts when it references vitest", async () => {
-    await writeFile(
-      join(tmpDir, "vite.config.ts"),
-      "import { defineConfig } from 'vitest/config'; export default defineConfig({ test: {} })",
-    );
-    expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("does not detect vitest from vite.config.ts without vitest references", async () => {
-    await writeFile(
-      join(tmpDir, "vite.config.ts"),
-      "import { defineConfig } from 'vite'; export default defineConfig({});",
-    );
+  it.each([
+    { content: "export default {}", filename: "jest.config.ts" },
+    { content: "module.exports = {}", filename: "jest.config.js" },
+    { content: "module.exports = {}", filename: "jest.config.cjs" },
+  ])("detects jest from $filename", async ({ filename, content }) => {
+    await writeFile(join(tmpDir, filename), content);
     expect(await detectRunner(tmpDir)).toBe("jest");
   });
 
-  it("detects jest from jest.config.ts", async () => {
-    await writeFile(join(tmpDir, "jest.config.ts"), "export default {}");
-    expect(await detectRunner(tmpDir)).toBe("jest");
+  it.each([
+    {
+      content:
+        "import { defineConfig } from 'vitest/config'; export default defineConfig({ test: {} })",
+      expected: "vitest" as const,
+      name: "references vitest/config",
+    },
+    {
+      content:
+        "import { defineConfig } from 'vite'; export default defineConfig({});",
+      expected: "jest" as const,
+      name: "references plain vite",
+    },
+  ])("detects $expected from vite.config.ts when it $name", async ({
+    content,
+    expected,
+  }) => {
+    await writeFile(join(tmpDir, "vite.config.ts"), content);
+    expect(await detectRunner(tmpDir)).toBe(expected);
   });
 
-  it("detects jest from jest.config.js", async () => {
-    await writeFile(join(tmpDir, "jest.config.js"), "module.exports = {}");
-    expect(await detectRunner(tmpDir)).toBe("jest");
-  });
-
-  it("detects jest from jest.config.cjs", async () => {
-    await writeFile(join(tmpDir, "jest.config.cjs"), "module.exports = {}");
-    expect(await detectRunner(tmpDir)).toBe("jest");
+  it.each([
+    {
+      expected: "jest" as const,
+      name: "package.json with jest key",
+      pkg: { jest: { testEnvironment: "node" } },
+    },
+    {
+      expected: "vitest" as const,
+      name: "package.json scripts containing vitest",
+      pkg: { scripts: { test: "vitest run" } },
+    },
+    {
+      expected: "jest" as const,
+      name: "package.json scripts containing jest",
+      pkg: { scripts: { test: "jest --coverage" } },
+    },
+    {
+      expected: "vitest" as const,
+      name: "package.json devDependencies vitest",
+      pkg: { devDependencies: { vitest: "^2.0.0" } },
+    },
+    {
+      expected: "jest" as const,
+      name: "package.json devDependencies jest",
+      pkg: { devDependencies: { jest: "^29.0.0" } },
+    },
+  ])("detects $expected from $name", async ({ pkg, expected }) => {
+    await writeFile(join(tmpDir, "package.json"), JSON.stringify(pkg));
+    expect(await detectRunner(tmpDir)).toBe(expected);
   });
 
   it("prefers vitest config file over jest config file", async () => {
     await writeFile(join(tmpDir, "vitest.config.ts"), "export default {}");
     await writeFile(join(tmpDir, "jest.config.ts"), "export default {}");
     expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("detects jest from package.json jest key", async () => {
-    await writeFile(
-      join(tmpDir, "package.json"),
-      JSON.stringify({ jest: { testEnvironment: "node" } }),
-    );
-    expect(await detectRunner(tmpDir)).toBe("jest");
-  });
-
-  it("detects vitest from package.json scripts containing vitest", async () => {
-    await writeFile(
-      join(tmpDir, "package.json"),
-      JSON.stringify({ scripts: { test: "vitest run" } }),
-    );
-    expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("detects jest from package.json scripts containing jest", async () => {
-    await writeFile(
-      join(tmpDir, "package.json"),
-      JSON.stringify({ scripts: { test: "jest --coverage" } }),
-    );
-    expect(await detectRunner(tmpDir)).toBe("jest");
-  });
-
-  it("detects vitest from package.json devDependencies", async () => {
-    await writeFile(
-      join(tmpDir, "package.json"),
-      JSON.stringify({ devDependencies: { vitest: "^2.0.0" } }),
-    );
-    expect(await detectRunner(tmpDir)).toBe("vitest");
-  });
-
-  it("detects jest from package.json devDependencies", async () => {
-    await writeFile(
-      join(tmpDir, "package.json"),
-      JSON.stringify({ devDependencies: { jest: "^29.0.0" } }),
-    );
-    expect(await detectRunner(tmpDir)).toBe("jest");
   });
 
   it("falls back to jest when no config files and no package.json", async () => {

--- a/src/runner/jest.test.ts
+++ b/src/runner/jest.test.ts
@@ -10,93 +10,77 @@ import { runJest } from "./jest.js";
 
 const mockExeca = vi.mocked(execa);
 
+function makeDiffFile(path: string, additions = 1): DiffFile {
+  return { addedLines: [], additions, deletions: 0, path };
+}
+
+function getInvocationArgs(): string[] {
+  return mockExeca.mock.calls[0][1] as string[];
+}
+
 describe("runJest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("invokes jest with coverage flags via npx by default", async () => {
-    const options: RunOptions = { cwd: "/project" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [1, 2], additions: 2, deletions: 0, path: "src/foo.ts" },
-    ];
-
-    await runJest(options, diffFiles);
+  it.each([
+    {
+      expectedBin: "npx",
+      expectedFirstArg: "jest",
+      name: "via npx by default",
+      options: { cwd: "/project" } as RunOptions,
+    },
+    {
+      expectedBin: "pnpm",
+      expectedFirstArg: "jest",
+      name: "with custom testCommand",
+      options: {
+        cwd: "/project",
+        testCommand: "pnpm jest",
+      } as RunOptions,
+    },
+  ])("invokes jest $name", async ({
+    options,
+    expectedBin,
+    expectedFirstArg,
+  }) => {
+    await runJest(options, [makeDiffFile("src/foo.ts")]);
 
     expect(mockExeca).toHaveBeenCalledOnce();
     const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
-    expect(bin).toBe("npx");
-    expect(args).toContain("jest");
-    expect(args).toContain("--coverage");
-    expect(args).toContain("--passWithNoTests");
-    expect(args).toContain("--findRelatedTests");
+    expect(bin).toBe(expectedBin);
+    expect(args[0]).toBe(expectedFirstArg);
   });
 
-  it("uses custom test command when provided", async () => {
-    const options: RunOptions = { cwd: "/project", testCommand: "pnpm jest" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/bar.ts" },
-    ];
-
-    await runJest(options, diffFiles);
-
-    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
-    expect(bin).toBe("pnpm");
-    expect(args[0]).toBe("jest");
-  });
-
-  it("adds --collectCoverageFrom for each diff file", async () => {
+  describe("CLI arguments", () => {
     const options: RunOptions = { cwd: "/project" };
     const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-      { addedLines: [], additions: 2, deletions: 0, path: "src/b.ts" },
+      makeDiffFile("src/a.ts"),
+      makeDiffFile("src/b.ts", 2),
     ];
 
-    await runJest(options, diffFiles);
-
-    const args = mockExeca.mock.calls[0][1] as string[];
-    expect(args).toContain("--collectCoverageFrom=src/a.ts");
-    expect(args).toContain("--collectCoverageFrom=src/b.ts");
-  });
-
-  it("passes diff file paths as positional arguments for --findRelatedTests", async () => {
-    const options: RunOptions = { cwd: "/project" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-      { addedLines: [], additions: 1, deletions: 0, path: "src/b.ts" },
-    ];
-
-    await runJest(options, diffFiles);
-
-    const args = mockExeca.mock.calls[0][1] as string[];
-    expect(args).toContain("src/a.ts");
-    expect(args).toContain("src/b.ts");
+    it.each([
+      ["--coverage"],
+      ["--passWithNoTests"],
+      ["--findRelatedTests"],
+      ["--coverageReporters=json-summary"],
+      ["--coverageReporters=json"],
+      ["--collectCoverageFrom=src/a.ts"],
+      ["--collectCoverageFrom=src/b.ts"],
+      ["src/a.ts"],
+      ["src/b.ts"],
+    ])("includes %s", async (flag) => {
+      await runJest(options, diffFiles);
+      expect(getInvocationArgs()).toContain(flag);
+    });
   });
 
   it("sets CI=true in environment", async () => {
-    const options: RunOptions = { cwd: "/project" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-    ];
-
-    await runJest(options, diffFiles);
+    await runJest({ cwd: "/project" }, [makeDiffFile("src/a.ts")]);
 
     const execaOptions = mockExeca.mock.calls[0].at(-1) as {
       env: Record<string, string>;
     };
     expect(execaOptions.env).toMatchObject({ CI: "true" });
-  });
-
-  it("uses coverage reporters json-summary and json", async () => {
-    const options: RunOptions = { cwd: "/project" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-    ];
-
-    await runJest(options, diffFiles);
-
-    const args = mockExeca.mock.calls[0][1] as string[];
-    expect(args).toContain("--coverageReporters=json-summary");
-    expect(args).toContain("--coverageReporters=json");
   });
 });

--- a/src/runner/vitest-runner.test.ts
+++ b/src/runner/vitest-runner.test.ts
@@ -13,6 +13,20 @@ import { runVitest } from "./vitest.js";
 
 const mockExeca = vi.mocked(execa);
 
+function makeDiffFile(path: string, additions = 1): DiffFile {
+  return { addedLines: [], additions, deletions: 0, path };
+}
+
+function getInvocationArgs(): string[] {
+  return mockExeca.mock.calls[0][1] as string[];
+}
+
+function extractCoverageIncludeValues(args: string[]): string[] {
+  return args
+    .map((a, i) => (a === "--coverage.include" ? args[i + 1] : null))
+    .filter((v): v is string => v != null);
+}
+
 describe("runVitest", () => {
   let tmpDir: string;
 
@@ -26,74 +40,61 @@ describe("runVitest", () => {
     await rm(tmpDir, { force: true, recursive: true });
   });
 
-  it("invokes vitest with coverage flags via npx by default", async () => {
-    const options: RunOptions = { cwd: tmpDir };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [1, 2], additions: 2, deletions: 0, path: "src/foo.ts" },
-    ];
-
-    await runVitest(options, diffFiles);
+  it.each([
+    {
+      expectedBin: "npx",
+      expectedFirstArg: "vitest",
+      makeOptions: (): RunOptions => ({ cwd: tmpDir }),
+      name: "via npx by default",
+    },
+    {
+      expectedBin: "pnpm",
+      expectedFirstArg: "vitest",
+      makeOptions: (): RunOptions => ({
+        cwd: tmpDir,
+        testCommand: "pnpm vitest",
+      }),
+      name: "with custom testCommand",
+    },
+  ])("invokes vitest $name", async ({
+    makeOptions,
+    expectedBin,
+    expectedFirstArg,
+  }) => {
+    await runVitest(makeOptions(), [makeDiffFile("src/foo.ts")]);
 
     expect(mockExeca).toHaveBeenCalledOnce();
     const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
-    expect(bin).toBe("npx");
-    expect(args).toContain("vitest");
-    expect(args).toContain("run");
-    expect(args).toContain("--coverage");
-    expect(args).toContain("--coverage.enabled=true");
-    expect(args).toContain("--coverage.provider=v8");
+    expect(bin).toBe(expectedBin);
+    expect(args[0]).toBe(expectedFirstArg);
   });
 
-  it("uses custom test command when provided", async () => {
-    const options: RunOptions = { cwd: tmpDir, testCommand: "pnpm vitest" };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
-    ];
+  describe("CLI arguments", () => {
+    it.each([
+      ["run"],
+      ["--coverage"],
+      ["--coverage.enabled=true"],
+      ["--coverage.provider=v8"],
+      ["--coverage.reporter=json"],
+      ["--coverage.reporter=json-summary"],
+    ])("includes %s", async (flag) => {
+      await runVitest({ cwd: tmpDir }, [makeDiffFile("src/foo.ts")]);
+      expect(getInvocationArgs()).toContain(flag);
+    });
 
-    await runVitest(options, diffFiles);
-
-    const [bin, args] = mockExeca.mock.calls[0] as [string, string[]];
-    expect(bin).toBe("pnpm");
-    expect(args[0]).toBe("vitest");
-  });
-
-  it("adds --coverage.include for each diff file", async () => {
-    const options: RunOptions = { cwd: tmpDir };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-      { addedLines: [], additions: 2, deletions: 0, path: "src/b.ts" },
-    ];
-
-    await runVitest(options, diffFiles);
-
-    const args = mockExeca.mock.calls[0][1] as string[];
-    const includeValues = args
-      .map((a, i) => (a === "--coverage.include" ? args[i + 1] : null))
-      .filter(Boolean);
-    expect(includeValues).toContain("src/a.ts");
-    expect(includeValues).toContain("src/b.ts");
-  });
-
-  it("uses json and json-summary coverage reporters", async () => {
-    const options: RunOptions = { cwd: tmpDir };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/foo.ts" },
-    ];
-
-    await runVitest(options, diffFiles);
-
-    const args = mockExeca.mock.calls[0][1] as string[];
-    expect(args).toContain("--coverage.reporter=json");
-    expect(args).toContain("--coverage.reporter=json-summary");
+    it("adds --coverage.include for each diff file", async () => {
+      await runVitest({ cwd: tmpDir }, [
+        makeDiffFile("src/a.ts"),
+        makeDiffFile("src/b.ts", 2),
+      ]);
+      const includes = extractCoverageIncludeValues(getInvocationArgs());
+      expect(includes).toContain("src/a.ts");
+      expect(includes).toContain("src/b.ts");
+    });
   });
 
   it("sets CI=true in environment", async () => {
-    const options: RunOptions = { cwd: tmpDir };
-    const diffFiles: DiffFile[] = [
-      { addedLines: [], additions: 1, deletions: 0, path: "src/a.ts" },
-    ];
-
-    await runVitest(options, diffFiles);
+    await runVitest({ cwd: tmpDir }, [makeDiffFile("src/a.ts")]);
 
     const execaOptions = mockExeca.mock.calls[0].at(-1) as {
       env: Record<string, string>;


### PR DESCRIPTION
Introduce .claude/rules/shared/test.md documenting Vitest testing
guidelines (parameterized tests via it.each / describe.each, factory
builders, mock cleanup, fixture teardown, assertion granularity).

Apply the rule to existing tests so equivalent input/output cases are
expressed as data tables instead of repeated it blocks. Behavior is
unchanged; the suite now expands from 77 to 107 cases via
parameterization across 6 test files.