### PR TITLE
Add PR inline review feature for diff-coverage results

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,13 @@ import {
   runCoverage,
   runTypecheck,
 } from "./core.js";
+import { GhNotAuthenticatedError, GhNotInstalledError } from "./github.js";
+import {
+  formatReviewResult,
+  NoPullRequestError,
+  type ReviewOptions,
+  runReview,
+} from "./review.js";
 import { detectRunner, type RunnerType } from "./runner/detect.js";
 
 type MeasureOpts = {
@@ -246,6 +253,98 @@ program
     } catch (err) {
       console.error("Error:", err instanceof Error ? err.message : err);
       process.exit(1);
+    }
+  });
+
+type ReviewCliOpts = {
+  base: string;
+  cwd: string;
+  dryRun?: boolean;
+  exclude?: string;
+  ext: string;
+  pr?: number;
+  runner: RunnerType | "auto";
+  threshold?: number;
+};
+
+const parseReviewCliOptions = async (
+  opts: ReviewCliOpts,
+): Promise<ReviewOptions> => {
+  const cwd = resolve(opts.cwd);
+  const extensions = opts.ext.split(",").map((e) => e.trim());
+  const config = await loadConfig(cwd);
+  const exclude = [
+    ...(config.exclude ?? []),
+    ...(opts.exclude ? opts.exclude.split(",").map((e) => e.trim()) : []),
+  ];
+  return {
+    base: opts.base,
+    cwd,
+    dryRun: opts.dryRun,
+    exclude,
+    extensions,
+    pr: opts.pr,
+    runner: opts.runner,
+    threshold: opts.threshold,
+  };
+};
+
+const handleReviewError = (err: unknown): never => {
+  if (err instanceof GhNotInstalledError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+  if (err instanceof GhNotAuthenticatedError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+  if (err instanceof NoPullRequestError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(2);
+  }
+  console.error("Error:", err instanceof Error ? err.message : err);
+  process.exit(1);
+};
+
+program
+  .command("review")
+  .description(
+    "Post inline review comments on the GitHub PR for the current branch (uses `gh` CLI for auth)",
+  )
+  .option("-b, --base <branch>", "Base branch to diff against", "main")
+  .option("-c, --cwd <path>", "Project root directory", process.cwd())
+  .option(
+    "-r, --runner <runner>",
+    "Test runner: jest | vitest | auto (default: auto)",
+    "auto",
+  )
+  .option("--pr <number>", "PR number override", (v) => Number.parseInt(v, 10))
+  .option(
+    "--threshold <number>",
+    "Minimum line coverage % (CLI exits 1 if below; review event is still COMMENT)",
+    Number.parseFloat,
+  )
+  .option("--dry-run", "Print planned comments without posting")
+  .option(
+    "--ext <extensions>",
+    "Comma-separated file extensions",
+    "ts,tsx,js,jsx",
+  )
+  .option(
+    "--exclude <patterns>",
+    "Comma-separated glob patterns to exclude files",
+  )
+  .action(async (rawOpts) => {
+    try {
+      const options = await parseReviewCliOptions(rawOpts as ReviewCliOpts);
+      console.error(
+        `📝 Reviewing PR for current branch (base: ${options.base})...`,
+      );
+      const outcome = await runReview(options);
+      console.log(formatReviewResult(outcome));
+      if (outcome.thresholdMet === false) process.exit(1);
+    } catch (err) {
+      handleReviewError(err);
     }
   });
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from "execa";
+import {
+  createReview,
+  ensureGhAuthenticated,
+  findPullRequestByBranch,
+  GhNotAuthenticatedError,
+  getPullRequest,
+  listReviewComments,
+  parseRepoSlug,
+} from "./github.js";
+
+const mockExeca = vi.mocked(execa);
+
+const stubOk = (stdout = "") =>
+  mockExeca.mockResolvedValueOnce({ stdout } as never);
+
+const stubFail = (stderr = "boom", code?: string) => {
+  const err = Object.assign(new Error(stderr), { code, stderr });
+  return mockExeca.mockRejectedValueOnce(err);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseRepoSlug", () => {
+  it.each([
+    {
+      expected: { owner: "ksugawara61", repo: "diff-coverage" },
+      input: "https://github.com/ksugawara61/diff-coverage.git",
+      name: "HTTPS with .git",
+    },
+    {
+      expected: { owner: "ksugawara61", repo: "diff-coverage" },
+      input: "https://github.com/ksugawara61/diff-coverage",
+      name: "HTTPS without .git",
+    },
+    {
+      expected: { owner: "ksugawara61", repo: "diff-coverage" },
+      input: "git@github.com:ksugawara61/diff-coverage.git",
+      name: "SSH shorthand with .git",
+    },
+    {
+      expected: { owner: "ksugawara61", repo: "diff-coverage" },
+      input: "git@github.com:ksugawara61/diff-coverage",
+      name: "SSH shorthand without .git",
+    },
+    {
+      expected: { owner: "ksugawara61", repo: "diff-coverage" },
+      input: "ssh://git@github.com/ksugawara61/diff-coverage.git",
+      name: "ssh:// URL",
+    },
+  ])("$name → owner/repo", ({ input, expected }) => {
+    expect(parseRepoSlug(input)).toEqual(expected);
+  });
+
+  it("throws on a non-GitHub URL", () => {
+    expect(() => parseRepoSlug("https://gitlab.com/owner/repo.git")).toThrow(
+      /Unsupported GitHub remote URL/,
+    );
+  });
+});
+
+describe("ensureGhAuthenticated", () => {
+  it("resolves when `gh auth status` succeeds", async () => {
+    stubOk("Logged in to github.com");
+    await expect(ensureGhAuthenticated()).resolves.toBeUndefined();
+  });
+
+  it("throws GhNotAuthenticatedError when `gh auth status` exits non-zero", async () => {
+    stubFail("not logged in");
+    await expect(ensureGhAuthenticated()).rejects.toBeInstanceOf(
+      GhNotAuthenticatedError,
+    );
+  });
+});
+
+describe("findPullRequestByBranch", () => {
+  const args = {
+    branch: "feature",
+    cwd: "/repo",
+    owner: "ksugawara61",
+    repo: "diff-coverage",
+  };
+
+  it("returns null when gh returns an empty array", async () => {
+    stubOk("[]");
+    expect(await findPullRequestByBranch(args)).toBeNull();
+  });
+
+  it("returns the first PR when results are present", async () => {
+    stubOk(
+      JSON.stringify([
+        {
+          baseRefName: "main",
+          headRefName: "feature",
+          headRefOid: "abc123",
+          number: 7,
+          state: "OPEN",
+          url: "https://github.com/x/y/pull/7",
+        },
+      ]),
+    );
+    const pr = await findPullRequestByBranch(args);
+    expect(pr?.number).toBe(7);
+    expect(pr?.headRefOid).toBe("abc123");
+  });
+
+  it("invokes gh with --repo, --head and --state flags", async () => {
+    stubOk("[]");
+    await findPullRequestByBranch(args);
+    const call = mockExeca.mock.calls[0];
+    expect(call[0]).toBe("gh");
+    expect(call[1]).toContain("pr");
+    expect(call[1]).toContain("list");
+    expect(call[1]).toContain("--head");
+    expect(call[1]).toContain("feature");
+    expect(call[1]).toContain("--repo");
+    expect(call[1]).toContain("ksugawara61/diff-coverage");
+    expect(call[1]).toContain("--state");
+    expect(call[1]).toContain("open");
+  });
+});
+
+describe("getPullRequest", () => {
+  it("calls `gh pr view <number>` and returns the parsed PR", async () => {
+    stubOk(
+      JSON.stringify({
+        baseRefName: "main",
+        headRefName: "feature",
+        headRefOid: "sha1",
+        number: 12,
+        state: "OPEN",
+        url: "https://github.com/o/r/pull/12",
+      }),
+    );
+    const pr = await getPullRequest({
+      cwd: "/repo",
+      owner: "o",
+      pullNumber: 12,
+      repo: "r",
+    });
+    expect(pr.number).toBe(12);
+    const call = mockExeca.mock.calls[0];
+    expect(call[1]).toContain("pr");
+    expect(call[1]).toContain("view");
+    expect(call[1]).toContain("12");
+  });
+});
+
+describe("listReviewComments", () => {
+  it("parses newline-delimited JSON lines from gh --paginate --jq", async () => {
+    const lines = [
+      JSON.stringify({
+        body: "first",
+        id: 1,
+        line: 10,
+        path: "src/a.ts",
+        start_line: null,
+      }),
+      JSON.stringify({
+        body: "second",
+        id: 2,
+        line: 20,
+        path: "src/b.ts",
+        start_line: 18,
+      }),
+      "",
+    ].join("\n");
+    stubOk(lines);
+
+    const comments = await listReviewComments({
+      cwd: "/repo",
+      owner: "o",
+      pullNumber: 1,
+      repo: "r",
+    });
+
+    expect(comments).toHaveLength(2);
+    expect(comments[0].body).toBe("first");
+    expect(comments[1].start_line).toBe(18);
+  });
+});
+
+describe("createReview", () => {
+  it("posts a JSON payload with event=COMMENT via stdin", async () => {
+    stubOk(JSON.stringify({ html_url: "https://x/review/1", id: 99 }));
+
+    const result = await createReview({
+      body: "summary",
+      comments: [
+        {
+          body: "uncovered",
+          line: 12,
+          path: "src/foo.ts",
+          side: "RIGHT",
+        },
+      ],
+      commitId: "deadbeef",
+      cwd: "/repo",
+      owner: "o",
+      pullNumber: 5,
+      repo: "r",
+    });
+
+    expect(result.id).toBe(99);
+    const call = mockExeca.mock.calls[0];
+    expect(call[1]).toContain("repos/o/r/pulls/5/reviews");
+    const opts = call[2] as { input?: string };
+    const payload = JSON.parse(opts.input ?? "{}") as {
+      body: string;
+      comments: { line: number; path: string }[];
+      commit_id: string;
+      event: string;
+    };
+    expect(payload.event).toBe("COMMENT");
+    expect(payload.commit_id).toBe("deadbeef");
+    expect(payload.body).toBe("summary");
+    expect(payload.comments[0]).toMatchObject({
+      line: 12,
+      path: "src/foo.ts",
+    });
+  });
+});

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,211 @@
+import { type ExecaError, execa } from "execa";
+
+export type RepoSlug = { owner: string; repo: string };
+
+export type GitHubPullRequest = {
+  baseRefName: string;
+  headRefName: string;
+  headRefOid: string;
+  number: number;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  url: string;
+};
+
+export type GitHubReviewComment = {
+  body: string;
+  id: number;
+  line: number | null;
+  path: string;
+  start_line: number | null;
+};
+
+export type ReviewCommentInput = {
+  body: string;
+  line: number;
+  path: string;
+  side: "RIGHT";
+  start_line?: number;
+  start_side?: "RIGHT";
+};
+
+export type CreateReviewParams = {
+  body: string;
+  comments: ReviewCommentInput[];
+  commitId: string;
+  cwd: string;
+  owner: string;
+  pullNumber: number;
+  repo: string;
+};
+
+export class GhNotInstalledError extends Error {
+  code = "NO_GH" as const;
+  constructor() {
+    super(
+      "GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com",
+    );
+    this.name = "GhNotInstalledError";
+  }
+}
+
+export class GhNotAuthenticatedError extends Error {
+  code = "NO_AUTH" as const;
+  constructor() {
+    super("GitHub CLI is not authenticated. Run `gh auth login` first.");
+    this.name = "GhNotAuthenticatedError";
+  }
+}
+
+export class GhApiError extends Error {
+  code = "GH_API" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "GhApiError";
+  }
+}
+
+const REPO_URL_PATTERNS: RegExp[] = [
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/,
+  /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/,
+  /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/,
+];
+
+export const parseRepoSlug = (remoteUrl: string): RepoSlug => {
+  const trimmed = remoteUrl.trim();
+  const match = REPO_URL_PATTERNS.map((re) => trimmed.match(re)).find(
+    (m): m is RegExpMatchArray => m !== null,
+  );
+  if (!match) {
+    throw new Error(`Unsupported GitHub remote URL: ${remoteUrl}`);
+  }
+  return { owner: match[1], repo: match[2] };
+};
+
+const isEnoent = (err: unknown): boolean =>
+  typeof err === "object" &&
+  err !== null &&
+  "code" in err &&
+  (err as { code?: string }).code === "ENOENT";
+
+const runGh = async (
+  args: string[],
+  options: { cwd?: string; input?: string } = {},
+): Promise<{ stdout: string }> => {
+  try {
+    const { input, cwd } = options;
+    const result = await execa("gh", args, {
+      cwd,
+      input,
+      reject: true,
+    });
+    return { stdout: result.stdout };
+  } catch (err) {
+    if (isEnoent(err)) throw new GhNotInstalledError();
+    const execErr = err as ExecaError;
+    const stderr =
+      typeof execErr.stderr === "string" ? execErr.stderr : String(execErr);
+    throw new GhApiError(`gh ${args.join(" ")} failed: ${stderr.trim()}`);
+  }
+};
+
+export const ensureGhAuthenticated = async (): Promise<void> => {
+  try {
+    await execa("gh", ["auth", "status"], { reject: true });
+  } catch (err) {
+    if (isEnoent(err)) throw new GhNotInstalledError();
+    throw new GhNotAuthenticatedError();
+  }
+};
+
+const PR_FIELDS = "number,headRefName,headRefOid,baseRefName,state,url";
+
+export const findPullRequestByBranch = async (args: {
+  branch: string;
+  cwd: string;
+  owner: string;
+  repo: string;
+}): Promise<GitHubPullRequest | null> => {
+  const { stdout } = await runGh(
+    [
+      "pr",
+      "list",
+      "--repo",
+      `${args.owner}/${args.repo}`,
+      "--head",
+      args.branch,
+      "--state",
+      "open",
+      "--json",
+      PR_FIELDS,
+    ],
+    { cwd: args.cwd },
+  );
+  const list = JSON.parse(stdout) as GitHubPullRequest[];
+  return list.length === 0 ? null : list[0];
+};
+
+export const getPullRequest = async (args: {
+  cwd: string;
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}): Promise<GitHubPullRequest> => {
+  const { stdout } = await runGh(
+    [
+      "pr",
+      "view",
+      String(args.pullNumber),
+      "--repo",
+      `${args.owner}/${args.repo}`,
+      "--json",
+      PR_FIELDS,
+    ],
+    { cwd: args.cwd },
+  );
+  return JSON.parse(stdout) as GitHubPullRequest;
+};
+
+export const listReviewComments = async (args: {
+  cwd: string;
+  owner: string;
+  pullNumber: number;
+  repo: string;
+}): Promise<GitHubReviewComment[]> => {
+  const { stdout } = await runGh(
+    [
+      "api",
+      "--paginate",
+      `repos/${args.owner}/${args.repo}/pulls/${args.pullNumber}/comments`,
+      "--jq",
+      ".[] | {id, path, line, start_line, body}",
+    ],
+    { cwd: args.cwd },
+  );
+  return stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as GitHubReviewComment);
+};
+
+export const createReview = async (
+  params: CreateReviewParams,
+): Promise<{ html_url: string; id: number }> => {
+  const payload = {
+    body: params.body,
+    comments: params.comments,
+    commit_id: params.commitId,
+    event: "COMMENT" as const,
+  };
+  const { stdout } = await runGh(
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${params.owner}/${params.repo}/pulls/${params.pullNumber}/reviews`,
+      "--input",
+      "-",
+    ],
+    { cwd: params.cwd, input: JSON.stringify(payload) },
+  );
+  return JSON.parse(stdout) as { html_url: string; id: number };
+};

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -11,6 +11,7 @@ import {
   loadConfig,
   runCoverage,
 } from "./core.js";
+import { formatReviewResult, runReview } from "./review.js";
 import { detectRunner } from "./runner/detect.js";
 
 const server = new McpServer({
@@ -301,6 +302,80 @@ server.tool(
       const runner = await detectRunner(resolve(cwd));
       return {
         content: [{ text: `Detected test runner: ${runner}`, type: "text" }],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+            type: "text",
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ─── Tool 5: review_pr_coverage ───────────────────────────────────────────────
+
+server.tool(
+  "review_pr_coverage",
+  "Post inline GitHub review comments for diff-coverage uncovered lines on the PR associated with the current branch. Uses `gh` CLI for authentication; the GitHub CLI must be installed and `gh auth login` completed. The review event is always COMMENT.",
+  {
+    base: z
+      .string()
+      .optional()
+      .default("main")
+      .describe("Base branch/ref to diff against (default: main)"),
+    cwd: z.string().describe("Absolute path to the project root"),
+    dryRun: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("If true, return planned comments without posting"),
+    exclude: z
+      .array(z.string())
+      .optional()
+      .describe("Glob patterns to exclude from coverage"),
+    extensions: z
+      .array(z.string())
+      .optional()
+      .describe("File extensions to include (default: ts,tsx,js,jsx)"),
+    pr: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "PR number override; auto-detected from current branch if omitted",
+      ),
+    runner: RunnerSchema,
+    threshold: z
+      .number()
+      .optional()
+      .describe(
+        "Minimum line coverage %; included in the summary body (review event is always COMMENT)",
+      ),
+  },
+  async ({ cwd, base, runner, threshold, pr, dryRun, exclude, extensions }) => {
+    try {
+      const outcome = await runReview({
+        base,
+        cwd: resolve(cwd),
+        dryRun,
+        exclude,
+        extensions,
+        pr,
+        runner,
+        threshold,
+      });
+      return {
+        content: [
+          { text: formatReviewResult(outcome), type: "text" },
+          { text: JSON.stringify(outcome, null, 2), type: "text" },
+        ],
+        isError: outcome.thresholdMet === false,
       };
     } catch (err) {
       return {

--- a/src/review.test.ts
+++ b/src/review.test.ts
@@ -1,0 +1,451 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+vi.mock("./core.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getDiffFiles: vi.fn(),
+    loadConfig: vi.fn().mockResolvedValue({}),
+    runCoverage: vi.fn(),
+  };
+});
+
+import { execa } from "execa";
+import {
+  type DiffCoverageResult,
+  type DiffFile,
+  type FileCoverage,
+  getDiffFiles,
+  runCoverage,
+} from "./core.js";
+import type { GitHubReviewComment } from "./github.js";
+import {
+  buildMarker,
+  buildPlannedComments,
+  filterAlreadyPosted,
+  formatReviewResult,
+  groupUncoveredRanges,
+  NoPullRequestError,
+  type PlannedComment,
+  type ReviewOutcome,
+  renderCommentBody,
+  renderReviewBody,
+  runReview,
+} from "./review.js";
+
+const mockExeca = vi.mocked(execa);
+const mockGetDiffFiles = vi.mocked(getDiffFiles);
+const mockRunCoverage = vi.mocked(runCoverage);
+
+const stubOk = (stdout: string) =>
+  mockExeca.mockResolvedValueOnce({ stdout } as never);
+
+const fileCoverage = (overrides: Partial<FileCoverage> = {}): FileCoverage => ({
+  branches: { covered: 0, pct: 0, total: 0 },
+  functions: { covered: 0, pct: 0, total: 0 },
+  lines: { covered: 0, pct: 0, total: 0 },
+  path: "src/foo.ts",
+  statements: { covered: 0, pct: 0, total: 0 },
+  uncoveredLines: [],
+  ...overrides,
+});
+
+const coverageResult = (
+  overrides: Partial<DiffCoverageResult> = {},
+): DiffCoverageResult => ({
+  files: [],
+  runner: "jest",
+  summary: {
+    branches: { covered: 0, pct: 0, total: 0 },
+    coveredFiles: 0,
+    functions: { covered: 0, pct: 0, total: 0 },
+    lines: { covered: 80, pct: 80, total: 100 },
+    statements: { covered: 80, pct: 80, total: 100 },
+    totalFiles: 1,
+  },
+  timestamp: "2026-04-28T00:00:00.000Z",
+  uncoveredFiles: [],
+  ...overrides,
+});
+
+const diffFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  addedLines: [],
+  additions: 0,
+  deletions: 0,
+  path: "src/foo.ts",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("groupUncoveredRanges", () => {
+  it.each([
+    {
+      added: [1, 2, 3, 4, 5],
+      expected: [{ end: 3, start: 1 }],
+      name: "merges consecutive uncovered lines",
+      uncovered: [1, 2, 3],
+    },
+    {
+      added: [1, 2, 3, 4, 5],
+      expected: [
+        { end: 1, start: 1 },
+        { end: 3, start: 3 },
+        { end: 5, start: 5 },
+      ],
+      name: "splits non-consecutive uncovered lines",
+      uncovered: [1, 3, 5],
+    },
+    {
+      added: [10, 11, 12, 13, 20, 21, 22],
+      expected: [
+        { end: 12, start: 10 },
+        { end: 22, start: 20 },
+      ],
+      name: "handles multiple separate ranges",
+      uncovered: [10, 11, 12, 20, 21, 22],
+    },
+    {
+      added: [5, 6, 7],
+      expected: [],
+      name: "returns empty when no uncovered lines",
+      uncovered: [],
+    },
+    {
+      added: [1, 5],
+      expected: [
+        { end: 1, start: 1 },
+        { end: 5, start: 5 },
+      ],
+      name: "does not bridge across non-added gaps",
+      uncovered: [1, 2, 3, 4, 5],
+    },
+  ])("$name", ({ uncovered, added, expected }) => {
+    expect(groupUncoveredRanges(uncovered, added)).toEqual(expected);
+  });
+
+  it("filters out uncovered lines not in addedLines", () => {
+    expect(groupUncoveredRanges([1, 2, 3], [2])).toEqual([
+      { end: 2, start: 2 },
+    ]);
+  });
+});
+
+describe("buildMarker", () => {
+  it("is deterministic for the same input", () => {
+    expect(buildMarker("src/foo.ts", 10, 20)).toBe(
+      buildMarker("src/foo.ts", 10, 20),
+    );
+  });
+
+  it("differs when path or range changes", () => {
+    const a = buildMarker("src/foo.ts", 10, 20);
+    const b = buildMarker("src/foo.ts", 10, 21);
+    const c = buildMarker("src/bar.ts", 10, 20);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe("renderCommentBody", () => {
+  it("renders single-line body", () => {
+    const body = renderCommentBody({
+      endLine: 42,
+      marker: "<!-- mark -->",
+      path: "src/foo.ts",
+      startLine: 42,
+    });
+    expect(body).toContain("(line 42)");
+    expect(body).toContain("<!-- mark -->");
+  });
+
+  it("renders multi-line body with line count", () => {
+    const body = renderCommentBody({
+      endLine: 47,
+      marker: "<!-- mark -->",
+      path: "src/foo.ts",
+      startLine: 42,
+    });
+    expect(body).toContain("lines 42–47");
+    expect(body).toContain("These 6 added lines");
+  });
+});
+
+describe("buildPlannedComments", () => {
+  it("emits one comment per uncovered range and intersects with addedLines", () => {
+    const result = coverageResult({
+      files: [
+        fileCoverage({
+          path: "src/foo.ts",
+          uncoveredLines: [10, 11, 12, 50],
+        }),
+      ],
+    });
+    const planned = buildPlannedComments(result, [
+      diffFile({ addedLines: [10, 11, 12, 50] }),
+    ]);
+
+    expect(planned).toHaveLength(2);
+    expect(planned[0]).toMatchObject({
+      endLine: 12,
+      path: "src/foo.ts",
+      startLine: 10,
+    });
+    expect(planned[1]).toMatchObject({
+      endLine: 50,
+      path: "src/foo.ts",
+      startLine: 50,
+    });
+  });
+});
+
+describe("filterAlreadyPosted", () => {
+  const planned: PlannedComment[] = [
+    {
+      body: "ignored",
+      endLine: 12,
+      marker: "<!-- diff-coverage:auto:abc1234 -->",
+      path: "src/a.ts",
+      startLine: 10,
+    },
+    {
+      body: "ignored",
+      endLine: 5,
+      marker: "<!-- diff-coverage:auto:def5678 -->",
+      path: "src/b.ts",
+      startLine: 5,
+    },
+  ];
+
+  const existingComment = (body: string): GitHubReviewComment => ({
+    body,
+    id: 1,
+    line: null,
+    path: "src/a.ts",
+    start_line: null,
+  });
+
+  it("skips planned comments whose marker already appears in existing comments", () => {
+    const { kept, skipped } = filterAlreadyPosted(planned, [
+      existingComment(
+        "Earlier text\n<!-- diff-coverage:auto:abc1234 -->\nmore",
+      ),
+    ]);
+    expect(skipped).toBe(1);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].marker).toContain("def5678");
+  });
+
+  it("keeps everything when no markers match", () => {
+    const { kept, skipped } = filterAlreadyPosted(planned, [
+      existingComment("unrelated comment"),
+    ]);
+    expect(skipped).toBe(0);
+    expect(kept).toHaveLength(2);
+  });
+});
+
+describe("renderReviewBody", () => {
+  it("includes summary and threshold pass/fail line", () => {
+    const body = renderReviewBody(coverageResult(), 90);
+    expect(body).toContain("Diff coverage report");
+    expect(body).toContain("Threshold: 90%");
+    expect(body).toContain("⚠️ below threshold");
+    expect(body).toContain("<!-- diff-coverage:auto:summary -->");
+  });
+
+  it("omits threshold line when threshold is undefined", () => {
+    const body = renderReviewBody(coverageResult());
+    expect(body).not.toContain("Threshold:");
+  });
+});
+
+describe("formatReviewResult", () => {
+  const baseOutcome = (
+    overrides: Partial<ReviewOutcome> = {},
+  ): ReviewOutcome => ({
+    coverage: coverageResult(),
+    dryRun: false,
+    planned: [],
+    posted: [],
+    pr: { headSha: "sha", number: 1, url: "https://x/pr/1" },
+    skippedExisting: 0,
+    thresholdMet: null,
+    ...overrides,
+  });
+
+  it.each([
+    {
+      expected: "Threshold: ✅ PASS",
+      name: "threshold met",
+      thresholdMet: true,
+    },
+    {
+      expected: "Threshold: ❌ FAIL",
+      name: "threshold not met",
+      thresholdMet: false,
+    },
+  ])("renders $name", ({ thresholdMet, expected }) => {
+    expect(formatReviewResult(baseOutcome({ thresholdMet }))).toContain(
+      expected,
+    );
+  });
+
+  it("renders dry-run mode when dryRun is true", () => {
+    expect(formatReviewResult(baseOutcome({ dryRun: true }))).toContain(
+      "dry-run",
+    );
+  });
+
+  it("includes posted review URL when present", () => {
+    const out = formatReviewResult(
+      baseOutcome({ postedReviewUrl: "https://x/review/9" }),
+    );
+    expect(out).toContain("Posted review: https://x/review/9");
+  });
+});
+
+describe("runReview", () => {
+  const mountSuccessfulPipeline = (overrides?: {
+    addedLines?: number[];
+    uncoveredLines?: number[];
+  }) => {
+    const addedLines = overrides?.addedLines ?? [10, 11, 12];
+    const uncoveredLines = overrides?.uncoveredLines ?? [10, 11, 12];
+
+    // 1. ensureGhAuthenticated → gh auth status
+    stubOk("Logged in");
+    // 2. detectGitContext → git rev-parse --abbrev-ref HEAD
+    stubOk("feature");
+    // 3. detectGitContext → git config --get remote.origin.url
+    stubOk("git@github.com:owner/repo.git");
+    // 4. resolvePr → gh pr list
+    stubOk(
+      JSON.stringify([
+        {
+          baseRefName: "main",
+          headRefName: "feature",
+          headRefOid: "deadbeef",
+          number: 42,
+          state: "OPEN",
+          url: "https://github.com/owner/repo/pull/42",
+        },
+      ]),
+    );
+
+    mockGetDiffFiles.mockResolvedValueOnce([
+      diffFile({ addedLines, path: "src/foo.ts" }),
+    ]);
+    mockRunCoverage.mockResolvedValueOnce(
+      coverageResult({
+        files: [fileCoverage({ path: "src/foo.ts", uncoveredLines })],
+      }),
+    );
+  };
+
+  it("posts a review with planned comments on the happy path", async () => {
+    mountSuccessfulPipeline();
+    // 5. listReviewComments
+    stubOk("");
+    // 6. createReview
+    stubOk(JSON.stringify({ html_url: "https://x/review/1", id: 999 }));
+
+    const outcome = await runReview({ cwd: "/repo" });
+
+    expect(outcome.posted).toHaveLength(1);
+    expect(outcome.skippedExisting).toBe(0);
+    expect(outcome.postedReviewUrl).toBe("https://x/review/1");
+    expect(outcome.pr.number).toBe(42);
+
+    const createReviewCall = mockExeca.mock.calls.at(-1);
+    expect(createReviewCall?.[1]).toContain(
+      "repos/owner/repo/pulls/42/reviews",
+    );
+    const opts = createReviewCall?.[2] as { input?: string };
+    const payload = JSON.parse(opts?.input ?? "{}") as {
+      comments: { line: number; path: string; start_line?: number }[];
+      commit_id: string;
+      event: string;
+    };
+    expect(payload.event).toBe("COMMENT");
+    expect(payload.commit_id).toBe("deadbeef");
+    expect(payload.comments[0]).toMatchObject({
+      line: 12,
+      path: "src/foo.ts",
+      start_line: 10,
+    });
+  });
+
+  it("throws NoPullRequestError when no PR is found", async () => {
+    // 1. ensureGhAuthenticated
+    stubOk("Logged in");
+    // 2. branch
+    stubOk("feature");
+    // 3. remote url
+    stubOk("git@github.com:owner/repo.git");
+    // 4. gh pr list → empty
+    stubOk("[]");
+
+    await expect(runReview({ cwd: "/repo" })).rejects.toBeInstanceOf(
+      NoPullRequestError,
+    );
+  });
+
+  it("does not call createReview in dryRun mode", async () => {
+    mountSuccessfulPipeline();
+    const outcome = await runReview({ cwd: "/repo", dryRun: true });
+
+    expect(outcome.dryRun).toBe(true);
+    expect(outcome.posted).toEqual([]);
+    expect(outcome.planned).toHaveLength(1);
+    // Only 4 gh/git calls (no listReviewComments, no createReview)
+    expect(mockExeca).toHaveBeenCalledTimes(4);
+  });
+
+  it("skips comments whose marker already exists on the PR", async () => {
+    mountSuccessfulPipeline();
+    const planned = buildPlannedComments(
+      coverageResult({
+        files: [
+          fileCoverage({
+            path: "src/foo.ts",
+            uncoveredLines: [10, 11, 12],
+          }),
+        ],
+      }),
+      [diffFile({ addedLines: [10, 11, 12], path: "src/foo.ts" })],
+    );
+    const existingMarker = planned[0].marker;
+    // listReviewComments returns the marker already
+    stubOk(
+      JSON.stringify({
+        body: `existing ${existingMarker}`,
+        id: 1,
+        line: 12,
+        path: "src/foo.ts",
+        start_line: 10,
+      }),
+    );
+    // createReview
+    stubOk(JSON.stringify({ html_url: "https://x/review/2", id: 1000 }));
+
+    const outcome = await runReview({ cwd: "/repo" });
+    expect(outcome.skippedExisting).toBe(1);
+    expect(outcome.posted).toHaveLength(0);
+  });
+
+  it("computes thresholdMet from coverage summary", async () => {
+    mountSuccessfulPipeline();
+    stubOk("");
+    stubOk(JSON.stringify({ html_url: "https://x/review/3", id: 1001 }));
+
+    const outcome = await runReview({ cwd: "/repo", threshold: 90 });
+    // summary.lines.pct is 80 in factory; 80 < 90
+    expect(outcome.thresholdMet).toBe(false);
+  });
+});

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,0 +1,403 @@
+import { createHash } from "node:crypto";
+import { execa } from "execa";
+import {
+  type DiffCoverageResult,
+  type DiffFile,
+  type FileCoverage,
+  getDiffFiles,
+  loadConfig,
+  type RunOptions,
+  runCoverage,
+} from "./core.js";
+import {
+  createReview,
+  ensureGhAuthenticated,
+  findPullRequestByBranch,
+  type GitHubPullRequest,
+  type GitHubReviewComment,
+  getPullRequest,
+  listReviewComments,
+  parseRepoSlug,
+  type ReviewCommentInput,
+} from "./github.js";
+
+export type ReviewOptions = {
+  base?: string;
+  cwd: string;
+  dryRun?: boolean;
+  exclude?: string[];
+  extensions?: string[];
+  pr?: number;
+  runner?: RunOptions["runner"];
+  threshold?: number;
+};
+
+export type Range = { end: number; start: number };
+
+export type PlannedComment = {
+  body: string;
+  endLine: number;
+  marker: string;
+  path: string;
+  startLine: number;
+};
+
+export type ReviewOutcome = {
+  coverage: DiffCoverageResult;
+  dryRun: boolean;
+  planned: PlannedComment[];
+  posted: PlannedComment[];
+  postedReviewUrl?: string;
+  pr: { headSha: string; number: number; url: string };
+  skippedExisting: number;
+  thresholdMet: boolean | null;
+};
+
+export class NoPullRequestError extends Error {
+  code = "NO_PR" as const;
+  constructor(branch: string) {
+    super(
+      `No open pull request found for branch "${branch}". Push the branch first or pass --pr.`,
+    );
+    this.name = "NoPullRequestError";
+  }
+}
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+export const groupUncoveredRanges = (
+  uncoveredLines: number[],
+  addedLines: number[],
+): Range[] => {
+  const addedSet = new Set(addedLines);
+  const candidates = uncoveredLines
+    .filter((n) => addedSet.has(n))
+    .sort((a, b) => a - b);
+  return candidates.reduce<Range[]>((acc, n) => {
+    const last = acc.at(-1);
+    if (last && last.end + 1 === n) {
+      last.end = n;
+    } else {
+      acc.push({ end: n, start: n });
+    }
+    return acc;
+  }, []);
+};
+
+export const buildMarker = (
+  path: string,
+  startLine: number,
+  endLine: number,
+): string => {
+  const hash = createHash("sha256")
+    .update(`${path}:${startLine}:${endLine}`)
+    .digest("hex")
+    .slice(0, 7);
+  return `<!-- diff-coverage:auto:${hash} -->`;
+};
+
+export const renderCommentBody = (args: {
+  endLine: number;
+  marker: string;
+  path: string;
+  startLine: number;
+}): string => {
+  const { startLine, endLine, marker } = args;
+  if (startLine === endLine) {
+    return [
+      marker,
+      `**Uncovered by tests** (line ${startLine})`,
+      "",
+      "This line was added in this PR but no test exercises it. Add coverage for this code path.",
+      "",
+      "_Posted by `diff-coverage`._",
+    ].join("\n");
+  }
+  const count = endLine - startLine + 1;
+  return [
+    marker,
+    `**Uncovered by tests** (lines ${startLine}–${endLine})`,
+    "",
+    `These ${count} added lines are not exercised by any test. Add coverage for this block.`,
+    "",
+    "_Posted by `diff-coverage`._",
+  ].join("\n");
+};
+
+const renderFilesBelowThreshold = (
+  files: FileCoverage[],
+  threshold: number,
+): string[] => {
+  const below = files.filter((f) => f.lines.pct < threshold);
+  if (below.length === 0) return [];
+  return [
+    "",
+    "Files below threshold:",
+    ...below.map((f) => `- \`${f.path}\` — ${f.lines.pct}%`),
+  ];
+};
+
+export const renderReviewBody = (
+  result: DiffCoverageResult,
+  threshold?: number,
+): string => {
+  const { summary } = result;
+  const lines: string[] = [
+    "## Diff coverage report",
+    "",
+    `- Lines: **${summary.lines.pct}%** (${summary.lines.covered}/${summary.lines.total})`,
+    `- Files changed: ${summary.totalFiles}`,
+  ];
+  if (threshold !== undefined) {
+    const pass = summary.lines.pct >= threshold;
+    lines.push(
+      `- Threshold: ${threshold}% — ${pass ? "✅ pass" : "⚠️ below threshold"}`,
+    );
+    lines.push(...renderFilesBelowThreshold(result.files, threshold));
+  }
+  lines.push("", "<!-- diff-coverage:auto:summary -->");
+  return lines.join("\n");
+};
+
+export const buildPlannedComments = (
+  result: DiffCoverageResult,
+  diffFiles: DiffFile[],
+): PlannedComment[] => {
+  const addedByPath = new Map(diffFiles.map((d) => [d.path, d.addedLines]));
+  return result.files.flatMap((f) => {
+    const added = addedByPath.get(f.path) ?? [];
+    const ranges = groupUncoveredRanges(f.uncoveredLines, added);
+    return ranges.map((r) => {
+      const marker = buildMarker(f.path, r.start, r.end);
+      return {
+        body: renderCommentBody({
+          endLine: r.end,
+          marker,
+          path: f.path,
+          startLine: r.start,
+        }),
+        endLine: r.end,
+        marker,
+        path: f.path,
+        startLine: r.start,
+      };
+    });
+  });
+};
+
+export const filterAlreadyPosted = (
+  planned: PlannedComment[],
+  existing: GitHubReviewComment[],
+): { kept: PlannedComment[]; skipped: number } => {
+  const existingMarkers = new Set(
+    existing
+      .map((c) => c.body.match(/<!-- diff-coverage:auto:[a-f0-9]{7} -->/)?.[0])
+      .filter((m): m is string => m !== undefined),
+  );
+  const kept = planned.filter((p) => !existingMarkers.has(p.marker));
+  return { kept, skipped: planned.length - kept.length };
+};
+
+const toReviewCommentInput = (p: PlannedComment): ReviewCommentInput =>
+  p.startLine === p.endLine
+    ? { body: p.body, line: p.endLine, path: p.path, side: "RIGHT" }
+    : {
+        body: p.body,
+        line: p.endLine,
+        path: p.path,
+        side: "RIGHT",
+        start_line: p.startLine,
+        start_side: "RIGHT",
+      };
+
+const renderThresholdLine = (met: boolean | null): string | null => {
+  if (met === null) return null;
+  return met ? "Threshold: ✅ PASS" : "Threshold: ❌ FAIL";
+};
+
+const renderPostedSection = (outcome: ReviewOutcome): string[] => {
+  if (outcome.dryRun) return ["Mode: dry-run (nothing posted)"];
+  if (!outcome.postedReviewUrl) return [];
+  return [
+    `Posted review: ${outcome.postedReviewUrl}`,
+    `Newly posted comments: ${outcome.posted.length}`,
+  ];
+};
+
+export const formatReviewResult = (outcome: ReviewOutcome): string => {
+  const thresholdLine = renderThresholdLine(outcome.thresholdMet);
+  const sections: (string | null)[] = [
+    "=== diff-coverage PR review ===",
+    "",
+    `PR: #${outcome.pr.number} ${outcome.pr.url}`,
+    `Head SHA: ${outcome.pr.headSha}`,
+    `Coverage: ${outcome.coverage.summary.lines.pct}% (${outcome.coverage.summary.lines.covered}/${outcome.coverage.summary.lines.total})`,
+    thresholdLine,
+    "",
+    `Planned inline comments: ${outcome.planned.length}`,
+    `Skipped (already posted): ${outcome.skippedExisting}`,
+    ...renderPostedSection(outcome),
+  ];
+  return sections.filter((s): s is string => s !== null).join("\n");
+};
+
+// ─── Git context ─────────────────────────────────────────────────────────────
+
+export const detectGitContext = async (
+  cwd: string,
+): Promise<{ branch: string; remoteUrl: string }> => {
+  const branchResult = await execa(
+    "git",
+    ["rev-parse", "--abbrev-ref", "HEAD"],
+    {
+      cwd,
+    },
+  );
+  const branch = branchResult.stdout.trim();
+  const remoteResult = await execa(
+    "git",
+    ["config", "--get", "remote.origin.url"],
+    { cwd },
+  );
+  const remoteUrl = remoteResult.stdout.trim();
+  return { branch, remoteUrl };
+};
+
+// ─── Orchestration ───────────────────────────────────────────────────────────
+
+const resolvePr = async (args: {
+  branch: string;
+  cwd: string;
+  override?: number;
+  owner: string;
+  repo: string;
+}): Promise<GitHubPullRequest> => {
+  if (args.override !== undefined) {
+    return getPullRequest({
+      cwd: args.cwd,
+      owner: args.owner,
+      pullNumber: args.override,
+      repo: args.repo,
+    });
+  }
+  const pr = await findPullRequestByBranch({
+    branch: args.branch,
+    cwd: args.cwd,
+    owner: args.owner,
+    repo: args.repo,
+  });
+  if (!pr) throw new NoPullRequestError(args.branch);
+  return pr;
+};
+
+const computeThresholdMet = (
+  result: DiffCoverageResult,
+  threshold?: number,
+): boolean | null => {
+  if (threshold === undefined) return null;
+  return result.summary.lines.pct >= threshold;
+};
+
+const runMeasurement = async (
+  opts: ReviewOptions,
+): Promise<{ coverage: DiffCoverageResult; diffFiles: DiffFile[] }> => {
+  const config = await loadConfig(opts.cwd);
+  const mergedExclude = [...(config.exclude ?? []), ...(opts.exclude ?? [])];
+  const diffFiles = await getDiffFiles(
+    opts.cwd,
+    opts.base,
+    opts.extensions,
+    undefined,
+    mergedExclude,
+  );
+  const coverage = await runCoverage(
+    {
+      base: opts.base,
+      cwd: opts.cwd,
+      extensions: opts.extensions,
+      runner: opts.runner,
+    },
+    diffFiles,
+  );
+  return { coverage, diffFiles };
+};
+
+const postReview = async (args: {
+  cwd: string;
+  kept: PlannedComment[];
+  owner: string;
+  pr: GitHubPullRequest;
+  repo: string;
+  reviewBody: string;
+}): Promise<string> => {
+  const result = await createReview({
+    body: args.reviewBody,
+    comments: args.kept.map(toReviewCommentInput),
+    commitId: args.pr.headRefOid,
+    cwd: args.cwd,
+    owner: args.owner,
+    pullNumber: args.pr.number,
+    repo: args.repo,
+  });
+  return result.html_url;
+};
+
+export const runReview = async (
+  opts: ReviewOptions,
+): Promise<ReviewOutcome> => {
+  await ensureGhAuthenticated();
+  const { branch, remoteUrl } = await detectGitContext(opts.cwd);
+  const { owner, repo } = parseRepoSlug(remoteUrl);
+  const pr = await resolvePr({
+    branch,
+    cwd: opts.cwd,
+    override: opts.pr,
+    owner,
+    repo,
+  });
+  const { coverage, diffFiles } = await runMeasurement(opts);
+  const planned = buildPlannedComments(coverage, diffFiles);
+  const thresholdMet = computeThresholdMet(coverage, opts.threshold);
+  const reviewBody = renderReviewBody(coverage, opts.threshold);
+  const prInfo = { headSha: pr.headRefOid, number: pr.number, url: pr.url };
+
+  if (opts.dryRun) {
+    return {
+      coverage,
+      dryRun: true,
+      planned,
+      posted: [],
+      pr: prInfo,
+      skippedExisting: 0,
+      thresholdMet,
+    };
+  }
+
+  const existing = await listReviewComments({
+    cwd: opts.cwd,
+    owner,
+    pullNumber: pr.number,
+    repo,
+  });
+  const { kept, skipped } = filterAlreadyPosted(planned, existing);
+
+  const postedReviewUrl = await postReview({
+    cwd: opts.cwd,
+    kept,
+    owner,
+    pr,
+    repo,
+    reviewBody,
+  });
+
+  return {
+    coverage,
+    dryRun: false,
+    planned,
+    posted: kept,
+    postedReviewUrl,
+    pr: prInfo,
+    skippedExisting: skipped,
+    thresholdMet,
+  };
+};


### PR DESCRIPTION
Adds a new `review` CLI subcommand and `review_pr_coverage` MCP tool that
post inline review comments on the GitHub PR for the current branch,
flagging lines that were added in the diff but uncovered by tests.

- `src/github.ts`: thin `gh` CLI wrapper (auth, find/get PR, list comments,
  create review). No new HTTP dependency.
- `src/review.ts`: orchestration — detects branch & remote, resolves PR,
  groups consecutive uncovered lines, dedupes against existing comments via
  a deterministic `<!-- diff-coverage:auto:<hash> -->` marker, and posts a
  COMMENT-event review.
- CLI: `diff-coverage review` with `--pr`, `--threshold`, `--dry-run` flags.
- MCP: new `review_pr_coverage` tool registered alongside existing tools.

https://claude.ai/code/session_013xm7dguuVZNbrMLRCint2g