### PR TITLE
refactor: extract CLI option schemas to per-command schema.ts using Zod

### DIFF
--- a/src/commands/detect/index.ts
+++ b/src/commands/detect/index.ts
@@ -6,11 +6,19 @@ import { DetectCLIOptsSchema } from "./schema.js";
 
 type DetectCliOptions = z.infer<typeof DetectCLIOptsSchema>;
 
-const detectAction = async (rawOpts: unknown): Promise<void> => {
-  const opts: DetectCliOptions = DetectCLIOptsSchema.parse(rawOpts);
+const runDetect = async (opts: DetectCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const runner = await detectRunner(cwd);
   console.log(`Detected runner: ${runner}`);
+};
+
+const detectAction = async (rawOpts: unknown): Promise<void> => {
+  const parsed = DetectCLIOptsSchema.safeParse(rawOpts);
+  if (!parsed.success) {
+    console.error(parsed.error.message);
+    process.exit(1);
+  }
+  await runDetect(parsed.data);
 };
 
 export const registerDetectCommand = (program: Command): void => {

--- a/src/commands/detect/index.ts
+++ b/src/commands/detect/index.ts
@@ -1,13 +1,14 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import type { z } from "zod";
 import { detectRunner } from "../../runner/detect.js";
+import { DetectCLIOptsSchema } from "./schema.js";
 
-type DetectCliOptions = {
-  cwd: string;
-};
+type DetectCliOptions = z.infer<typeof DetectCLIOptsSchema>;
 
-const detectAction = async (rawOpts: DetectCliOptions): Promise<void> => {
-  const cwd = resolve(rawOpts.cwd);
+const detectAction = async (rawOpts: unknown): Promise<void> => {
+  const opts: DetectCliOptions = DetectCLIOptsSchema.parse(rawOpts);
+  const cwd = resolve(opts.cwd);
   const runner = await detectRunner(cwd);
   console.log(`Detected runner: ${runner}`);
 };

--- a/src/commands/detect/schema.ts
+++ b/src/commands/detect/schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const DetectCLIOptsSchema = z.object({
+  cwd: z.string(),
+});

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -7,8 +7,7 @@ import { DiffCLIOptsSchema } from "./schema.js";
 
 type DiffCliOptions = z.infer<typeof DiffCLIOptsSchema>;
 
-const diffAction = async (rawOpts: unknown): Promise<void> => {
-  const opts: DiffCliOptions = DiffCLIOptsSchema.parse(rawOpts);
+const runDiff = async (opts: DiffCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
   const exclude = await resolveExcludePatterns(cwd, opts.exclude);
@@ -28,6 +27,15 @@ const diffAction = async (rawOpts: unknown): Promise<void> => {
   for (const file of files) {
     console.log(`${file.path}  (+${file.additions}/-${file.deletions})`);
   }
+};
+
+const diffAction = async (rawOpts: unknown): Promise<void> => {
+  const parsed = DiffCLIOptsSchema.safeParse(rawOpts);
+  if (!parsed.success) {
+    console.error(parsed.error.message);
+    process.exit(1);
+  }
+  await runDiff(parsed.data);
 };
 
 export const registerDiffCommand = (program: Command): void => {

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -1,23 +1,21 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import type { z } from "zod";
 import { getDiffFiles } from "../../shared/diff.js";
 import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
+import { DiffCLIOptsSchema } from "./schema.js";
 
-type DiffCliOptions = {
-  base: string;
-  cwd: string;
-  exclude?: string;
-  ext: string;
-};
+type DiffCliOptions = z.infer<typeof DiffCLIOptsSchema>;
 
-const diffAction = async (rawOpts: DiffCliOptions): Promise<void> => {
-  const cwd = resolve(rawOpts.cwd);
-  const extensions = parseCsv(rawOpts.ext);
-  const exclude = await resolveExcludePatterns(cwd, rawOpts.exclude);
+const diffAction = async (rawOpts: unknown): Promise<void> => {
+  const opts: DiffCliOptions = DiffCLIOptsSchema.parse(rawOpts);
+  const cwd = resolve(opts.cwd);
+  const extensions = parseCsv(opts.ext);
+  const exclude = await resolveExcludePatterns(cwd, opts.exclude);
 
   const files = await getDiffFiles(
     cwd,
-    rawOpts.base,
+    opts.base,
     extensions,
     undefined,
     exclude,

--- a/src/commands/diff/schema.ts
+++ b/src/commands/diff/schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const DiffCLIOptsSchema = z.object({
+  base: z.string().default("main"),
+  cwd: z.string(),
+  exclude: z.string().optional(),
+  ext: z.string().default("ts,tsx,js,jsx"),
+});

--- a/src/commands/measure/index.ts
+++ b/src/commands/measure/index.ts
@@ -10,8 +10,7 @@ import { MeasureCLIOptsSchema } from "./schema.js";
 
 type MeasureCliOptions = z.infer<typeof MeasureCLIOptsSchema>;
 
-const measureAction = async (rawOpts: unknown): Promise<void> => {
-  const opts: MeasureCliOptions = MeasureCLIOptsSchema.parse(rawOpts);
+const runMeasure = async (opts: MeasureCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
   const runner = await resolveRunner(cwd, opts.runner);
@@ -74,6 +73,15 @@ const measureAction = async (rawOpts: unknown): Promise<void> => {
     console.error("Error:", err instanceof Error ? err.message : err);
     process.exit(1);
   }
+};
+
+const measureAction = async (rawOpts: unknown): Promise<void> => {
+  const parsed = MeasureCLIOptsSchema.safeParse(rawOpts);
+  if (!parsed.success) {
+    console.error(parsed.error.message);
+    process.exit(1);
+  }
+  await runMeasure(parsed.data);
 };
 
 export const registerMeasureCommand = (program: Command): void => {

--- a/src/commands/measure/index.ts
+++ b/src/commands/measure/index.ts
@@ -1,38 +1,30 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
-import type { RunnerType } from "../../runner/detect.js";
+import type { z } from "zod";
 import { runCoverage } from "../../shared/coverage.js";
 import { getDiffFiles } from "../../shared/diff.js";
 import { formatResult } from "../../shared/format.js";
 import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
 import { resolveRunner } from "../../shared/runner.js";
+import { MeasureCLIOptsSchema } from "./schema.js";
 
-type MeasureCliOptions = {
-  base: string;
-  cmd?: string;
-  cwd: string;
-  diffOnly?: boolean;
-  exclude?: string;
-  ext: string;
-  json?: boolean;
-  runner: RunnerType | "auto";
-  threshold?: number;
-};
+type MeasureCliOptions = z.infer<typeof MeasureCLIOptsSchema>;
 
-const measureAction = async (rawOpts: MeasureCliOptions): Promise<void> => {
-  const cwd = resolve(rawOpts.cwd);
-  const extensions = parseCsv(rawOpts.ext);
-  const runner = await resolveRunner(cwd, rawOpts.runner);
+const measureAction = async (rawOpts: unknown): Promise<void> => {
+  const opts: MeasureCliOptions = MeasureCLIOptsSchema.parse(rawOpts);
+  const cwd = resolve(opts.cwd);
+  const extensions = parseCsv(opts.ext);
+  const runner = await resolveRunner(cwd, opts.runner);
 
   console.error(
-    `📊 Measuring diff coverage against ${rawOpts.base} (runner: ${runner})...`,
+    `📊 Measuring diff coverage against ${opts.base} (runner: ${runner})...`,
   );
 
   try {
-    const exclude = await resolveExcludePatterns(cwd, rawOpts.exclude);
+    const exclude = await resolveExcludePatterns(cwd, opts.exclude);
     const diffFiles = await getDiffFiles(
       cwd,
-      rawOpts.base,
+      opts.base,
       extensions,
       undefined,
       exclude,
@@ -47,7 +39,7 @@ const measureAction = async (rawOpts: MeasureCliOptions): Promise<void> => {
       `📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`,
     );
 
-    if (rawOpts.diffOnly) {
+    if (opts.diffOnly) {
       console.log(diffFiles.map((f) => f.path).join("\n"));
       process.exit(0);
     }
@@ -57,24 +49,24 @@ const measureAction = async (rawOpts: MeasureCliOptions): Promise<void> => {
 
     const result = await runCoverage(
       {
-        base: rawOpts.base,
+        base: opts.base,
         cwd,
         extensions,
         runner,
-        testCommand: rawOpts.cmd,
+        testCommand: opts.cmd,
       },
       diffFiles,
     );
 
-    if (rawOpts.json) {
+    if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
-      console.log(formatResult(result, rawOpts.threshold));
+      console.log(formatResult(result, opts.threshold));
     }
 
     if (
-      rawOpts.threshold !== undefined &&
-      result.summary.lines.pct < rawOpts.threshold
+      opts.threshold !== undefined &&
+      result.summary.lines.pct < opts.threshold
     ) {
       process.exit(1);
     }

--- a/src/commands/measure/schema.ts
+++ b/src/commands/measure/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { RunnerEnumSchema } from "../../shared/schema.js";
+
+export const MeasureCLIOptsSchema = z.object({
+  base: z.string().default("main"),
+  cmd: z.string().optional(),
+  cwd: z.string(),
+  diffOnly: z.boolean().optional(),
+  exclude: z.string().optional(),
+  ext: z.string().default("ts,tsx,js,jsx"),
+  json: z.boolean().optional(),
+  runner: RunnerEnumSchema.default("auto"),
+  threshold: z.number().optional(),
+});

--- a/src/commands/review/index.ts
+++ b/src/commands/review/index.ts
@@ -28,8 +28,7 @@ const handleReviewError = (err: unknown): never => {
   process.exit(1);
 };
 
-const reviewAction = async (rawOpts: unknown): Promise<void> => {
-  const opts: ReviewCliOptions = ReviewCLIOptsSchema.parse(rawOpts);
+const runReviewCommand = async (opts: ReviewCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
   const exclude = await resolveExcludePatterns(cwd, opts.exclude);
@@ -51,6 +50,15 @@ const reviewAction = async (rawOpts: unknown): Promise<void> => {
   } catch (err) {
     handleReviewError(err);
   }
+};
+
+const reviewAction = async (rawOpts: unknown): Promise<void> => {
+  const parsed = ReviewCLIOptsSchema.safeParse(rawOpts);
+  if (!parsed.success) {
+    console.error(parsed.error.message);
+    process.exit(1);
+  }
+  await runReviewCommand(parsed.data);
 };
 
 export const registerReviewCommand = (program: Command): void => {

--- a/src/commands/review/index.ts
+++ b/src/commands/review/index.ts
@@ -1,46 +1,15 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
-import type { RunnerType } from "../../runner/detect.js";
+import type { z } from "zod";
 import {
   GhNotAuthenticatedError,
   GhNotInstalledError,
 } from "../../shared/github.js";
 import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
-import {
-  formatReviewResult,
-  NoPullRequestError,
-  type ReviewOptions,
-  runReview,
-} from "./review.js";
+import { formatReviewResult, NoPullRequestError, runReview } from "./review.js";
+import { ReviewCLIOptsSchema } from "./schema.js";
 
-type ReviewCliOptions = {
-  base: string;
-  cwd: string;
-  dryRun?: boolean;
-  exclude?: string;
-  ext: string;
-  pr?: number;
-  runner: RunnerType | "auto";
-  threshold?: number;
-};
-
-const parseReviewCliOptions = async (
-  rawOpts: ReviewCliOptions,
-): Promise<ReviewOptions> => {
-  const cwd = resolve(rawOpts.cwd);
-  const extensions = parseCsv(rawOpts.ext);
-  const exclude = await resolveExcludePatterns(cwd, rawOpts.exclude);
-  return {
-    base: rawOpts.base,
-    cwd,
-    dryRun: rawOpts.dryRun,
-    exclude,
-    extensions,
-    pr: rawOpts.pr,
-    runner: rawOpts.runner,
-    threshold: rawOpts.threshold,
-  };
-};
+type ReviewCliOptions = z.infer<typeof ReviewCLIOptsSchema>;
 
 const handleReviewError = (err: unknown): never => {
   if (err instanceof GhNotInstalledError) {
@@ -59,13 +28,24 @@ const handleReviewError = (err: unknown): never => {
   process.exit(1);
 };
 
-const reviewAction = async (rawOpts: ReviewCliOptions): Promise<void> => {
+const reviewAction = async (rawOpts: unknown): Promise<void> => {
+  const opts: ReviewCliOptions = ReviewCLIOptsSchema.parse(rawOpts);
+  const cwd = resolve(opts.cwd);
+  const extensions = parseCsv(opts.ext);
+  const exclude = await resolveExcludePatterns(cwd, opts.exclude);
+
   try {
-    const options = await parseReviewCliOptions(rawOpts);
-    console.error(
-      `📝 Reviewing PR for current branch (base: ${options.base})...`,
-    );
-    const outcome = await runReview(options);
+    console.error(`📝 Reviewing PR for current branch (base: ${opts.base})...`);
+    const outcome = await runReview({
+      base: opts.base,
+      cwd,
+      dryRun: opts.dryRun,
+      exclude,
+      extensions,
+      pr: opts.pr,
+      runner: opts.runner,
+      threshold: opts.threshold,
+    });
     console.log(formatReviewResult(outcome));
     if (outcome.thresholdMet === false) process.exit(1);
   } catch (err) {

--- a/src/commands/review/schema.ts
+++ b/src/commands/review/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { RunnerEnumSchema } from "../../shared/schema.js";
+
+export const ReviewCLIOptsSchema = z.object({
+  base: z.string().default("main"),
+  cwd: z.string(),
+  dryRun: z.boolean().optional(),
+  exclude: z.string().optional(),
+  ext: z.string().default("ts,tsx,js,jsx"),
+  pr: z.number().int().positive().optional(),
+  runner: RunnerEnumSchema.default("auto"),
+  threshold: z.number().optional(),
+});

--- a/src/commands/typecheck/index.ts
+++ b/src/commands/typecheck/index.ts
@@ -1,26 +1,23 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import type { z } from "zod";
 import { getDiffFiles } from "../../shared/diff.js";
 import { parseCsv } from "../../shared/options.js";
 import { formatTypecheckResult } from "./format.js";
+import { TypecheckCLIOptsSchema } from "./schema.js";
 import { runTypecheck } from "./typecheck.js";
 
-type TypecheckCliOptions = {
-  base: string;
-  cmd?: string;
-  cwd: string;
-  ext: string;
-  json?: boolean;
-};
+type TypecheckCliOptions = z.infer<typeof TypecheckCLIOptsSchema>;
 
-const typecheckAction = async (rawOpts: TypecheckCliOptions): Promise<void> => {
-  const cwd = resolve(rawOpts.cwd);
-  const extensions = parseCsv(rawOpts.ext);
+const typecheckAction = async (rawOpts: unknown): Promise<void> => {
+  const opts: TypecheckCliOptions = TypecheckCLIOptsSchema.parse(rawOpts);
+  const cwd = resolve(opts.cwd);
+  const extensions = parseCsv(opts.ext);
 
-  console.error(`🔍 Type-checking diff against ${rawOpts.base}...`);
+  console.error(`🔍 Type-checking diff against ${opts.base}...`);
 
   try {
-    const diffFiles = await getDiffFiles(cwd, rawOpts.base, extensions);
+    const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
 
     if (diffFiles.length === 0) {
       console.log("No changed TypeScript files found.");
@@ -32,9 +29,9 @@ const typecheckAction = async (rawOpts: TypecheckCliOptions): Promise<void> => {
     );
     console.error("⚙️  Running tsc...\n");
 
-    const result = await runTypecheck(cwd, diffFiles, rawOpts.cmd);
+    const result = await runTypecheck(cwd, diffFiles, opts.cmd);
 
-    if (rawOpts.json) {
+    if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
       console.log(formatTypecheckResult(result));

--- a/src/commands/typecheck/index.ts
+++ b/src/commands/typecheck/index.ts
@@ -9,8 +9,9 @@ import { runTypecheck } from "./typecheck.js";
 
 type TypecheckCliOptions = z.infer<typeof TypecheckCLIOptsSchema>;
 
-const typecheckAction = async (rawOpts: unknown): Promise<void> => {
-  const opts: TypecheckCliOptions = TypecheckCLIOptsSchema.parse(rawOpts);
+const runTypecheckCommand = async (
+  opts: TypecheckCliOptions,
+): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
 
@@ -44,6 +45,15 @@ const typecheckAction = async (rawOpts: unknown): Promise<void> => {
     console.error("Error:", err instanceof Error ? err.message : err);
     process.exit(1);
   }
+};
+
+const typecheckAction = async (rawOpts: unknown): Promise<void> => {
+  const parsed = TypecheckCLIOptsSchema.safeParse(rawOpts);
+  if (!parsed.success) {
+    console.error(parsed.error.message);
+    process.exit(1);
+  }
+  await runTypecheckCommand(parsed.data);
 };
 
 export const registerTypecheckCommand = (program: Command): void => {

--- a/src/commands/typecheck/schema.ts
+++ b/src/commands/typecheck/schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const TypecheckCLIOptsSchema = z.object({
+  base: z.string().default("main"),
+  cmd: z.string().optional(),
+  cwd: z.string(),
+  ext: z.string().default("ts,tsx,mts,cts"),
+  json: z.boolean().optional(),
+});

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,15 +10,14 @@ import { loadConfig } from "./shared/config.js";
 import { type FileDetail, runCoverage } from "./shared/coverage.js";
 import { getDiffFiles } from "./shared/diff.js";
 import { formatResult } from "./shared/format.js";
+import { RunnerEnumSchema } from "./shared/schema.js";
 
 const server = new McpServer({
   name: "diff-coverage",
   version: "0.1.0",
 });
 
-const RunnerSchema = z
-  .enum(["jest", "vitest", "auto"])
-  .optional()
+const RunnerSchema = RunnerEnumSchema.optional()
   .default("auto")
   .describe(
     "Test runner to use. 'auto' detects from vitest.config.* / jest.config.* / package.json",

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const RunnerEnumSchema = z.enum(["jest", "vitest", "auto"]);


### PR DESCRIPTION
各コマンドの手書き型定義 (type *CliOptions) を Zod スキーマに置き換え、
action の境界で Schema.parse() による検証を行うよう変更。
RunnerEnumSchema を src/shared/schema.ts に切り出し、
MCP サーバーと CLI が同じプリミティブを参照できるようにした。

https://claude.ai/code/session_01PDjM5LeN7pBGLyhdkPSTwk