### PR TITLE
refactor: extract measure/diff orchestrators to deduplicate CLI and MCP entrypoints

### DIFF
--- a/src/commands/diff/diff.test.ts
+++ b/src/commands/diff/diff.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/config.js", () => ({
+  loadConfig: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("../../shared/diff.js", () => ({
+  getDiffFiles: vi.fn(),
+}));
+
+import { loadConfig } from "../../shared/config.js";
+import { type DiffFile, getDiffFiles } from "../../shared/diff.js";
+import { formatDiffFiles, runDiffFiles } from "./diff.js";
+
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockGetDiffFiles = vi.mocked(getDiffFiles);
+
+const diffFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  addedLines: [],
+  additions: 1,
+  deletions: 0,
+  path: "src/foo.ts",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLoadConfig.mockResolvedValue({});
+});
+
+describe("runDiffFiles", () => {
+  it("merges config.exclude with opts.exclude and forwards to getDiffFiles", async () => {
+    mockLoadConfig.mockResolvedValueOnce({ exclude: ["a.ts"] });
+    mockGetDiffFiles.mockResolvedValueOnce([diffFile()]);
+
+    const result = await runDiffFiles({
+      base: "main",
+      cwd: "/repo",
+      exclude: ["b.ts"],
+      extensions: ["ts"],
+    });
+
+    expect(mockGetDiffFiles).toHaveBeenCalledWith(
+      "/repo",
+      "main",
+      ["ts"],
+      undefined,
+      ["a.ts", "b.ts"],
+    );
+    expect(result.files).toHaveLength(1);
+  });
+});
+
+describe("formatDiffFiles", () => {
+  it("returns the empty-state message when files is empty", () => {
+    expect(formatDiffFiles([])).toBe("No changed source files.");
+  });
+
+  it("renders compact one-line-per-file format by default", () => {
+    const out = formatDiffFiles([
+      diffFile({ additions: 5, deletions: 2, path: "src/a.ts" }),
+      diffFile({ additions: 1, deletions: 0, path: "src/b.ts" }),
+    ]);
+    expect(out).toBe("src/a.ts  (+5/-2)\nsrc/b.ts  (+1/-0)");
+  });
+
+  it("renders verbose format with addedLines preview when showAddedLines is true", () => {
+    const out = formatDiffFiles(
+      [
+        diffFile({
+          addedLines: [10, 11, 12],
+          additions: 3,
+          deletions: 0,
+          path: "src/a.ts",
+        }),
+      ],
+      { showAddedLines: true },
+    );
+    expect(out).toContain("Changed files (1):");
+    expect(out).toContain("src/a.ts  (+3 additions, -0 deletions)");
+    expect(out).toContain("Added lines: 10, 11, 12");
+  });
+
+  it("truncates the addedLines preview after 10 entries", () => {
+    const addedLines = Array.from({ length: 12 }, (_, i) => i + 1);
+    const out = formatDiffFiles(
+      [diffFile({ addedLines, additions: 12, path: "src/a.ts" })],
+      { showAddedLines: true },
+    );
+    expect(out).toContain("1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ...");
+    expect(out).not.toContain(", 11");
+  });
+
+  it("omits the addedLines line when there are no added lines", () => {
+    const out = formatDiffFiles(
+      [diffFile({ addedLines: [], path: "src/a.ts" })],
+      { showAddedLines: true },
+    );
+    expect(out).not.toContain("Added lines:");
+  });
+});

--- a/src/commands/diff/diff.ts
+++ b/src/commands/diff/diff.ts
@@ -1,0 +1,55 @@
+import { type DiffFile, getDiffFiles } from "../../shared/diff.js";
+import { mergeExcludePatterns } from "../../shared/options.js";
+
+export type DiffFilesOptions = {
+  base?: string;
+  cwd: string;
+  exclude?: string[];
+  extensions?: string[];
+};
+
+export type DiffFilesOutcome = {
+  files: DiffFile[];
+};
+
+export const runDiffFiles = async (
+  opts: DiffFilesOptions,
+): Promise<DiffFilesOutcome> => {
+  const exclude = await mergeExcludePatterns(opts.cwd, opts.exclude);
+  const files = await getDiffFiles(
+    opts.cwd,
+    opts.base,
+    opts.extensions,
+    undefined,
+    exclude,
+  );
+  return { files };
+};
+
+const ADDED_LINES_PREVIEW_LIMIT = 10;
+
+const renderAddedLinesPreview = (addedLines: number[]): string => {
+  if (addedLines.length === 0) return "";
+  const preview = addedLines.slice(0, ADDED_LINES_PREVIEW_LIMIT).join(", ");
+  const more = addedLines.length > ADDED_LINES_PREVIEW_LIMIT ? " ..." : "";
+  return `\n  Added lines: ${preview}${more}`;
+};
+
+export const formatDiffFiles = (
+  files: DiffFile[],
+  opts?: { showAddedLines?: boolean },
+): string => {
+  if (files.length === 0) return "No changed source files.";
+
+  if (opts?.showAddedLines) {
+    const lines = files.map(
+      (f) =>
+        `${f.path}  (+${f.additions} additions, -${f.deletions} deletions)${renderAddedLinesPreview(f.addedLines)}`,
+    );
+    return `Changed files (${files.length}):\n\n${lines.join("\n\n")}`;
+  }
+
+  return files
+    .map((f) => `${f.path}  (+${f.additions}/-${f.deletions})`)
+    .join("\n");
+};

--- a/src/commands/diff/index.ts
+++ b/src/commands/diff/index.ts
@@ -1,32 +1,20 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
 import type { z } from "zod";
-import { getDiffFiles } from "../../shared/diff.js";
-import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
+import { parseCsv, parseCsvOption } from "../../shared/options.js";
+import { formatDiffFiles, runDiffFiles } from "./diff.js";
 import { DiffCLIOptsSchema } from "./schema.js";
 
 type DiffCliOptions = z.infer<typeof DiffCLIOptsSchema>;
 
-const runDiff = async (opts: DiffCliOptions): Promise<void> => {
-  const cwd = resolve(opts.cwd);
-  const extensions = parseCsv(opts.ext);
-  const exclude = await resolveExcludePatterns(cwd, opts.exclude);
-
-  const files = await getDiffFiles(
-    cwd,
-    opts.base,
-    extensions,
-    undefined,
-    exclude,
-  );
-  if (files.length === 0) {
-    console.log("No changed source files.");
-    return;
-  }
-
-  for (const file of files) {
-    console.log(`${file.path}  (+${file.additions}/-${file.deletions})`);
-  }
+const runDiffCommand = async (opts: DiffCliOptions): Promise<void> => {
+  const { files } = await runDiffFiles({
+    base: opts.base,
+    cwd: resolve(opts.cwd),
+    exclude: parseCsvOption(opts.exclude),
+    extensions: parseCsv(opts.ext),
+  });
+  console.log(formatDiffFiles(files));
 };
 
 const diffAction = async (rawOpts: unknown): Promise<void> => {
@@ -35,7 +23,7 @@ const diffAction = async (rawOpts: unknown): Promise<void> => {
     console.error(parsed.error.message);
     process.exit(1);
   }
-  await runDiff(parsed.data);
+  await runDiffCommand(parsed.data);
 };
 
 export const registerDiffCommand = (program: Command): void => {

--- a/src/commands/measure/index.ts
+++ b/src/commands/measure/index.ts
@@ -1,18 +1,19 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
 import type { z } from "zod";
-import { runCoverage } from "../../shared/coverage.js";
-import { getDiffFiles } from "../../shared/diff.js";
 import { formatResult } from "../../shared/format.js";
-import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
+import { parseCsv, parseCsvOption } from "../../shared/options.js";
 import { resolveRunner } from "../../shared/runner.js";
+import { formatDiffFiles } from "../diff/diff.js";
+import { measureWithDiffFiles, resolveMeasureDiffFiles } from "./measure.js";
 import { MeasureCLIOptsSchema } from "./schema.js";
 
 type MeasureCliOptions = z.infer<typeof MeasureCLIOptsSchema>;
 
-const runMeasure = async (opts: MeasureCliOptions): Promise<void> => {
+const runMeasureCommand = async (opts: MeasureCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
+  const exclude = parseCsvOption(opts.exclude);
   const runner = await resolveRunner(cwd, opts.runner);
 
   console.error(
@@ -20,14 +21,12 @@ const runMeasure = async (opts: MeasureCliOptions): Promise<void> => {
   );
 
   try {
-    const exclude = await resolveExcludePatterns(cwd, opts.exclude);
-    const diffFiles = await getDiffFiles(
+    const diffFiles = await resolveMeasureDiffFiles({
+      base: opts.base,
       cwd,
-      opts.base,
-      extensions,
-      undefined,
       exclude,
-    );
+      extensions,
+    });
 
     if (diffFiles.length === 0) {
       console.log("No changed source files found.");
@@ -39,34 +38,33 @@ const runMeasure = async (opts: MeasureCliOptions): Promise<void> => {
     );
 
     if (opts.diffOnly) {
-      console.log(diffFiles.map((f) => f.path).join("\n"));
+      console.log(formatDiffFiles(diffFiles));
       process.exit(0);
     }
 
     const runnerLabel = runner === "vitest" ? "Vitest" : "Jest";
     console.error(`🧪 Running ${runnerLabel}...\n`);
 
-    const result = await runCoverage(
+    const outcome = await measureWithDiffFiles(
       {
         base: opts.base,
         cwd,
+        exclude,
         extensions,
         runner,
         testCommand: opts.cmd,
+        threshold: opts.threshold,
       },
       diffFiles,
     );
 
     if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify(outcome.coverage, null, 2));
     } else {
-      console.log(formatResult(result, opts.threshold));
+      console.log(formatResult(outcome.coverage, opts.threshold));
     }
 
-    if (
-      opts.threshold !== undefined &&
-      result.summary.lines.pct < opts.threshold
-    ) {
+    if (outcome.thresholdMet === false) {
       process.exit(1);
     }
   } catch (err) {
@@ -81,7 +79,7 @@ const measureAction = async (rawOpts: unknown): Promise<void> => {
     console.error(parsed.error.message);
     process.exit(1);
   }
-  await runMeasure(parsed.data);
+  await runMeasureCommand(parsed.data);
 };
 
 export const registerMeasureCommand = (program: Command): void => {

--- a/src/commands/measure/measure.test.ts
+++ b/src/commands/measure/measure.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/config.js", () => ({
+  loadConfig: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("../../shared/coverage.js", () => ({
+  runCoverage: vi.fn(),
+}));
+vi.mock("../../shared/diff.js", () => ({
+  getDiffFiles: vi.fn(),
+}));
+
+import { loadConfig } from "../../shared/config.js";
+import { type DiffCoverageResult, runCoverage } from "../../shared/coverage.js";
+import { type DiffFile, getDiffFiles } from "../../shared/diff.js";
+import {
+  computeThresholdMet,
+  type MeasureOutcome,
+  measureWithDiffFiles,
+  resolveMeasureDiffFiles,
+  runMeasure,
+} from "./measure.js";
+
+const mockLoadConfig = vi.mocked(loadConfig);
+const mockGetDiffFiles = vi.mocked(getDiffFiles);
+const mockRunCoverage = vi.mocked(runCoverage);
+
+const coverageResult = (
+  overrides: Partial<DiffCoverageResult> = {},
+): DiffCoverageResult => ({
+  files: [],
+  runner: "jest",
+  summary: {
+    branches: { covered: 0, pct: 0, total: 0 },
+    coveredFiles: 0,
+    functions: { covered: 0, pct: 0, total: 0 },
+    lines: { covered: 80, pct: 80, total: 100 },
+    statements: { covered: 80, pct: 80, total: 100 },
+    totalFiles: 1,
+  },
+  timestamp: "2026-04-28T00:00:00.000Z",
+  uncoveredFiles: [],
+  ...overrides,
+});
+
+const diffFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  addedLines: [],
+  additions: 0,
+  deletions: 0,
+  path: "src/foo.ts",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLoadConfig.mockResolvedValue({});
+});
+
+describe("computeThresholdMet", () => {
+  const result = coverageResult();
+
+  it.each([
+    {
+      expected: null,
+      name: "returns null when threshold is undefined",
+      threshold: undefined,
+    },
+    {
+      expected: true,
+      name: "returns true when pct >= threshold",
+      threshold: 80,
+    },
+    {
+      expected: true,
+      name: "returns true when pct equals threshold",
+      threshold: 80,
+    },
+    {
+      expected: false,
+      name: "returns false when pct < threshold",
+      threshold: 90,
+    },
+  ])("$name", ({ threshold, expected }) => {
+    expect(computeThresholdMet(result, threshold)).toBe(expected);
+  });
+});
+
+describe("resolveMeasureDiffFiles", () => {
+  it("merges loadConfig.exclude with opts.exclude before calling getDiffFiles", async () => {
+    mockLoadConfig.mockResolvedValueOnce({ exclude: ["a.ts"] });
+    mockGetDiffFiles.mockResolvedValueOnce([]);
+
+    await resolveMeasureDiffFiles({
+      base: "main",
+      cwd: "/repo",
+      exclude: ["b.ts"],
+      extensions: ["ts"],
+    });
+
+    expect(mockGetDiffFiles).toHaveBeenCalledWith(
+      "/repo",
+      "main",
+      ["ts"],
+      undefined,
+      ["a.ts", "b.ts"],
+    );
+  });
+
+  it("treats missing config.exclude and opts.exclude as empty arrays", async () => {
+    mockLoadConfig.mockResolvedValueOnce({});
+    mockGetDiffFiles.mockResolvedValueOnce([]);
+
+    await resolveMeasureDiffFiles({ cwd: "/repo" });
+
+    expect(mockGetDiffFiles).toHaveBeenCalledWith(
+      "/repo",
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+  });
+});
+
+describe("measureWithDiffFiles", () => {
+  const baseOpts = { cwd: "/repo" };
+
+  it("returns coverage, diffFiles, and thresholdMet computed from coverage summary", async () => {
+    const files = [diffFile({ path: "src/a.ts" })];
+    const coverage = coverageResult();
+    mockRunCoverage.mockResolvedValueOnce(coverage);
+
+    const outcome = await measureWithDiffFiles(
+      { ...baseOpts, threshold: 90 },
+      files,
+    );
+
+    expect(outcome).toEqual<MeasureOutcome>({
+      coverage,
+      diffFiles: files,
+      thresholdMet: false,
+    });
+  });
+
+  it("passes runner / testCommand / extensions through to runCoverage", async () => {
+    mockRunCoverage.mockResolvedValueOnce(coverageResult());
+
+    await measureWithDiffFiles(
+      {
+        base: "develop",
+        cwd: "/repo",
+        extensions: ["ts", "tsx"],
+        runner: "vitest",
+        testCommand: "pnpm vitest",
+      },
+      [],
+    );
+
+    expect(mockRunCoverage).toHaveBeenCalledWith(
+      {
+        base: "develop",
+        cwd: "/repo",
+        extensions: ["ts", "tsx"],
+        runner: "vitest",
+        testCommand: "pnpm vitest",
+      },
+      [],
+    );
+  });
+});
+
+describe("runMeasure", () => {
+  it("composes diff resolution and coverage measurement", async () => {
+    const files = [diffFile({ path: "src/a.ts" })];
+    mockLoadConfig.mockResolvedValueOnce({ exclude: ["x"] });
+    mockGetDiffFiles.mockResolvedValueOnce(files);
+    mockRunCoverage.mockResolvedValueOnce(coverageResult());
+
+    const outcome = await runMeasure({
+      base: "main",
+      cwd: "/repo",
+      exclude: ["y"],
+      extensions: ["ts"],
+      threshold: 50,
+    });
+
+    expect(mockGetDiffFiles).toHaveBeenCalledWith(
+      "/repo",
+      "main",
+      ["ts"],
+      undefined,
+      ["x", "y"],
+    );
+    expect(outcome.diffFiles).toBe(files);
+    expect(outcome.thresholdMet).toBe(true);
+  });
+
+  it("still returns an outcome when no diff files are found (runCoverage short-circuits)", async () => {
+    mockGetDiffFiles.mockResolvedValueOnce([]);
+    mockRunCoverage.mockResolvedValueOnce(
+      coverageResult({
+        summary: {
+          branches: { covered: 0, pct: 0, total: 0 },
+          coveredFiles: 0,
+          functions: { covered: 0, pct: 0, total: 0 },
+          lines: { covered: 0, pct: 0, total: 0 },
+          statements: { covered: 0, pct: 0, total: 0 },
+          totalFiles: 0,
+        },
+      }),
+    );
+
+    const outcome = await runMeasure({ cwd: "/repo" });
+
+    expect(outcome.diffFiles).toEqual([]);
+    expect(outcome.thresholdMet).toBeNull();
+  });
+});

--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -1,0 +1,69 @@
+import {
+  type DiffCoverageResult,
+  type RunOptions,
+  runCoverage,
+} from "../../shared/coverage.js";
+import { type DiffFile, getDiffFiles } from "../../shared/diff.js";
+import { mergeExcludePatterns } from "../../shared/options.js";
+
+export type MeasureOptions = {
+  base?: string;
+  cwd: string;
+  exclude?: string[];
+  extensions?: string[];
+  runner?: RunOptions["runner"];
+  testCommand?: string;
+  threshold?: number;
+};
+
+export type MeasureOutcome = {
+  coverage: DiffCoverageResult;
+  diffFiles: DiffFile[];
+  thresholdMet: boolean | null;
+};
+
+export const computeThresholdMet = (
+  result: DiffCoverageResult,
+  threshold?: number,
+): boolean | null => {
+  if (threshold === undefined) return null;
+  return result.summary.lines.pct >= threshold;
+};
+
+export const resolveMeasureDiffFiles = async (opts: {
+  base?: string;
+  cwd: string;
+  exclude?: string[];
+  extensions?: string[];
+}): Promise<DiffFile[]> => {
+  const exclude = await mergeExcludePatterns(opts.cwd, opts.exclude);
+  return getDiffFiles(opts.cwd, opts.base, opts.extensions, undefined, exclude);
+};
+
+export const measureWithDiffFiles = async (
+  opts: MeasureOptions,
+  diffFiles: DiffFile[],
+): Promise<MeasureOutcome> => {
+  const coverage = await runCoverage(
+    {
+      base: opts.base,
+      cwd: opts.cwd,
+      extensions: opts.extensions,
+      runner: opts.runner,
+      testCommand: opts.testCommand,
+    },
+    diffFiles,
+  );
+  return {
+    coverage,
+    diffFiles,
+    thresholdMet: computeThresholdMet(coverage, opts.threshold),
+  };
+};
+
+export const runMeasure = async (
+  opts: MeasureOptions,
+): Promise<MeasureOutcome> => {
+  const diffFiles = await resolveMeasureDiffFiles(opts);
+  return measureWithDiffFiles(opts, diffFiles);
+};

--- a/src/commands/review/index.ts
+++ b/src/commands/review/index.ts
@@ -5,7 +5,7 @@ import {
   GhNotAuthenticatedError,
   GhNotInstalledError,
 } from "../../shared/github.js";
-import { parseCsv, resolveExcludePatterns } from "../../shared/options.js";
+import { parseCsv, parseCsvOption } from "../../shared/options.js";
 import { formatReviewResult, NoPullRequestError, runReview } from "./review.js";
 import { ReviewCLIOptsSchema } from "./schema.js";
 
@@ -29,18 +29,14 @@ const handleReviewError = (err: unknown): never => {
 };
 
 const runReviewCommand = async (opts: ReviewCliOptions): Promise<void> => {
-  const cwd = resolve(opts.cwd);
-  const extensions = parseCsv(opts.ext);
-  const exclude = await resolveExcludePatterns(cwd, opts.exclude);
-
   try {
     console.error(`📝 Reviewing PR for current branch (base: ${opts.base})...`);
     const outcome = await runReview({
       base: opts.base,
-      cwd,
+      cwd: resolve(opts.cwd),
       dryRun: opts.dryRun,
-      exclude,
-      extensions,
+      exclude: parseCsvOption(opts.exclude),
+      extensions: parseCsv(opts.ext),
       pr: opts.pr,
       runner: opts.runner,
       threshold: opts.threshold,

--- a/src/commands/review/review.ts
+++ b/src/commands/review/review.ts
@@ -1,13 +1,11 @@
 import { createHash } from "node:crypto";
 import { execa } from "execa";
-import { loadConfig } from "../../shared/config.js";
-import {
-  type DiffCoverageResult,
-  type FileCoverage,
-  type RunOptions,
-  runCoverage,
+import type {
+  DiffCoverageResult,
+  FileCoverage,
+  RunOptions,
 } from "../../shared/coverage.js";
-import { type DiffFile, getDiffFiles } from "../../shared/diff.js";
+import type { DiffFile } from "../../shared/diff.js";
 import {
   createReview,
   ensureGhAuthenticated,
@@ -19,6 +17,7 @@ import {
   parseRepoSlug,
   type ReviewCommentInput,
 } from "../../shared/github.js";
+import { runMeasure } from "../measure/measure.js";
 
 export type ReviewOptions = {
   base?: string;
@@ -289,38 +288,6 @@ const resolvePr = async (args: {
   return pr;
 };
 
-const computeThresholdMet = (
-  result: DiffCoverageResult,
-  threshold?: number,
-): boolean | null => {
-  if (threshold === undefined) return null;
-  return result.summary.lines.pct >= threshold;
-};
-
-const runMeasurement = async (
-  opts: ReviewOptions,
-): Promise<{ coverage: DiffCoverageResult; diffFiles: DiffFile[] }> => {
-  const config = await loadConfig(opts.cwd);
-  const mergedExclude = [...(config.exclude ?? []), ...(opts.exclude ?? [])];
-  const diffFiles = await getDiffFiles(
-    opts.cwd,
-    opts.base,
-    opts.extensions,
-    undefined,
-    mergedExclude,
-  );
-  const coverage = await runCoverage(
-    {
-      base: opts.base,
-      cwd: opts.cwd,
-      extensions: opts.extensions,
-      runner: opts.runner,
-    },
-    diffFiles,
-  );
-  return { coverage, diffFiles };
-};
-
 const postReview = async (args: {
   cwd: string;
   kept: PlannedComment[];
@@ -354,9 +321,15 @@ export const runReview = async (
     owner,
     repo,
   });
-  const { coverage, diffFiles } = await runMeasurement(opts);
+  const { coverage, diffFiles, thresholdMet } = await runMeasure({
+    base: opts.base,
+    cwd: opts.cwd,
+    exclude: opts.exclude,
+    extensions: opts.extensions,
+    runner: opts.runner,
+    threshold: opts.threshold,
+  });
   const planned = buildPlannedComments(coverage, diffFiles);
-  const thresholdMet = computeThresholdMet(coverage, opts.threshold);
   const reviewBody = renderReviewBody(coverage, opts.threshold);
   const prInfo = { headSha: pr.headRefOid, number: pr.number, url: pr.url };
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,11 +4,11 @@ import { resolve } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { formatDiffFiles, runDiffFiles } from "./commands/diff/diff.js";
+import { runMeasure } from "./commands/measure/measure.js";
 import { formatReviewResult, runReview } from "./commands/review/review.js";
 import { detectRunner } from "./runner/detect.js";
-import { loadConfig } from "./shared/config.js";
-import { type FileDetail, runCoverage } from "./shared/coverage.js";
-import { getDiffFiles } from "./shared/diff.js";
+import type { FileDetail } from "./shared/coverage.js";
 import { formatResult } from "./shared/format.js";
 import { RunnerEnumSchema } from "./shared/schema.js";
 
@@ -25,41 +25,33 @@ const RunnerSchema = RunnerEnumSchema.optional()
 
 // ─── Coverage detail helpers ──────────────────────────────────────────────────
 
-function collectUncoveredStatements(fileData: FileDetail): number[] {
-  const lines: Set<number> = new Set();
-  for (const [id, count] of Object.entries(fileData.s ?? {})) {
-    if (count === 0) {
-      const loc = fileData.statementMap?.[id]?.start?.line;
-      if (loc) lines.add(loc);
-    }
-  }
-  return [...lines].sort((a, b) => a - b);
-}
+const collectUncoveredStatements = (fileData: FileDetail): number[] => {
+  const lines = Object.entries(fileData.s ?? {})
+    .filter(([, count]) => count === 0)
+    .map(([id]) => fileData.statementMap?.[id]?.start?.line)
+    .filter((line): line is number => typeof line === "number");
+  return [...new Set(lines)].sort((a, b) => a - b);
+};
 
-function collectUncoveredFunctions(fileData: FileDetail): string[] {
-  const result: string[] = [];
-  for (const [id, count] of Object.entries(fileData.f ?? {})) {
-    if (count === 0) {
-      const fn = fileData.fnMap?.[id];
-      if (fn) result.push(`${fn.name} (line ${fn.loc?.start?.line})`);
-    }
-  }
-  return result;
-}
+const collectUncoveredFunctions = (fileData: FileDetail): string[] =>
+  Object.entries(fileData.f ?? {})
+    .filter(([, count]) => count === 0)
+    .map(([id]) => fileData.fnMap?.[id])
+    .filter((fn): fn is NonNullable<typeof fn> => fn !== undefined)
+    .map((fn) => `${fn.name} (line ${fn.loc?.start?.line})`);
 
-function collectUncoveredBranches(fileData: FileDetail): number[] {
-  const lines: Set<number> = new Set();
-  for (const [id, counts] of Object.entries(fileData.b ?? {})) {
-    for (const [i, count] of counts.entries()) {
-      const loc =
+const collectUncoveredBranches = (fileData: FileDetail): number[] => {
+  const lines = Object.entries(fileData.b ?? {}).flatMap(([id, counts]) =>
+    counts
+      .map((count, i) =>
         count === 0
           ? fileData.branchMap?.[id]?.locations?.[i]?.start?.line
-          : undefined;
-      if (loc) lines.add(loc);
-    }
-  }
-  return [...lines].sort((a, b) => a - b);
-}
+          : undefined,
+      )
+      .filter((line): line is number => typeof line === "number"),
+  );
+  return [...new Set(lines)].sort((a, b) => a - b);
+};
 
 // ─── Tool 1: measure_diff_coverage ───────────────────────────────────────────
 
@@ -110,20 +102,18 @@ server.tool(
     exclude,
     threshold,
   }) => {
-    const absPath = resolve(cwd);
-
     try {
-      const config = await loadConfig(absPath);
-      const mergedExclude = [...(config.exclude ?? []), ...(exclude ?? [])];
-      const diffFiles = await getDiffFiles(
-        absPath,
+      const outcome = await runMeasure({
         base,
+        cwd: resolve(cwd),
+        exclude,
         extensions,
-        undefined,
-        mergedExclude,
-      );
+        runner,
+        testCommand,
+        threshold,
+      });
 
-      if (diffFiles.length === 0) {
+      if (outcome.diffFiles.length === 0) {
         return {
           content: [
             {
@@ -134,21 +124,12 @@ server.tool(
         };
       }
 
-      const result = await runCoverage(
-        { base, cwd: absPath, extensions, runner, testCommand },
-        diffFiles,
-      );
-
-      const formatted = formatResult(result, threshold);
-      const passed =
-        threshold === undefined || result.summary.lines.pct >= threshold;
-
       return {
         content: [
-          { text: formatted, type: "text" },
-          { text: JSON.stringify(result, null, 2), type: "text" },
+          { text: formatResult(outcome.coverage, threshold), type: "text" },
+          { text: JSON.stringify(outcome.coverage, null, 2), type: "text" },
         ],
-        isError: !passed,
+        isError: outcome.thresholdMet === false,
       };
     } catch (err) {
       return {
@@ -184,35 +165,16 @@ server.tool(
   },
   async ({ cwd, base, extensions, exclude }) => {
     try {
-      const absPath = resolve(cwd);
-      const config = await loadConfig(absPath);
-      const mergedExclude = [...(config.exclude ?? []), ...(exclude ?? [])];
-      const files = await getDiffFiles(
-        absPath,
+      const { files } = await runDiffFiles({
         base,
+        cwd: resolve(cwd),
+        exclude,
         extensions,
-        undefined,
-        mergedExclude,
-      );
-
-      if (files.length === 0) {
-        return {
-          content: [{ text: "No changed source files found.", type: "text" }],
-        };
-      }
-
-      const lines = files.map(
-        (f) =>
-          `${f.path}  (+${f.additions} additions, -${f.deletions} deletions)` +
-          (f.addedLines.length > 0
-            ? `\n  Added lines: ${f.addedLines.slice(0, 10).join(", ")}${f.addedLines.length > 10 ? " ..." : ""}`
-            : ""),
-      );
-
+      });
       return {
         content: [
           {
-            text: `Changed files (${files.length}):\n\n${lines.join("\n\n")}`,
+            text: formatDiffFiles(files, { showAddedLines: true }),
             type: "text",
           },
         ],

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -9,10 +9,10 @@ export const parseCsv = (value: string): string[] =>
 export const parseCsvOption = (value: string | undefined): string[] =>
   value ? parseCsv(value) : [];
 
-export const resolveExcludePatterns = async (
+export const mergeExcludePatterns = async (
   cwd: string,
-  excludeOption: string | undefined,
+  extras: string[] | undefined,
 ): Promise<string[]> => {
   const config = await loadConfig(cwd);
-  return [...(config.exclude ?? []), ...parseCsvOption(excludeOption)];
+  return [...(config.exclude ?? []), ...(extras ?? [])];
 };


### PR DESCRIPTION
CLI commands and MCP tools were each reimplementing the same business logic
(exclude merging, getDiffFiles, runCoverage, threshold computation), making
divergence likely. This mirrors the existing review.ts pattern across measure
and diff:

- Add commands/measure/measure.ts (runMeasure / measureWithDiffFiles /
  resolveMeasureDiffFiles / computeThresholdMet) and commands/diff/diff.ts
  (runDiffFiles / formatDiffFiles), consumed by both CLI and MCP.
- Replace shared/options.ts resolveExcludePatterns with mergeExcludePatterns,
  used internally by orchestrators as a single source of truth.
- Fold review.ts runMeasurement into runMeasure, eliminating the third copy
  of the measure pipeline.
- CLI wrappers handle CSV→array, progress logs, exit codes; MCP wrappers
  handle isError mapping. No business logic in either layer.