### PR TITLE
feat: make base optional, default to git merge-base HEAD main

### DIFF
--- a/src/presentations/cli/commands/diff-schema.ts
+++ b/src/presentations/cli/commands/diff-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const DiffCLIOptsSchema = z.object({
-  base: z.string().default("main"),
+  base: z.string().optional(),
   cwd: z.string(),
   exclude: z.string().optional(),
   ext: z.string().default("ts,tsx,js,jsx"),

--- a/src/presentations/cli/commands/diff.ts
+++ b/src/presentations/cli/commands/diff.ts
@@ -33,7 +33,10 @@ export const registerDiffCommand = (program: Command): void => {
   program
     .command("diff")
     .description("List changed source files without running tests")
-    .option("-b, --base <branch>", "Base branch to diff against", "main")
+    .option(
+      "-b, --base <branch>",
+      "Base branch for diff (default: merge-base of HEAD and main)",
+    )
     .option("-c, --cwd <path>", "Project root directory", process.cwd())
     .option(
       "--ext <extensions>",

--- a/src/presentations/cli/commands/measure-schema.ts
+++ b/src/presentations/cli/commands/measure-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { RunnerEnumSchema } from "../../../applications/shared/runner-enum.js";
 
 export const MeasureCLIOptsSchema = z.object({
-  base: z.string().default("main"),
+  base: z.string().optional(),
   cmd: z.string().optional(),
   cwd: z.string(),
   diffOnly: z.boolean().optional(),

--- a/src/presentations/cli/commands/measure.ts
+++ b/src/presentations/cli/commands/measure.ts
@@ -20,7 +20,7 @@ const runMeasureCommand = async (opts: MeasureCliOptions): Promise<void> => {
   const runner = await resolveRunner(cwd, opts.runner);
 
   console.error(
-    `📊 Measuring diff coverage against ${opts.base} (runner: ${runner})...`,
+    `📊 Measuring diff coverage against ${opts.base ?? "merge-base of HEAD and main"} (runner: ${runner})...`,
   );
 
   try {
@@ -89,7 +89,10 @@ export const registerMeasureCommand = (program: Command): void => {
   program
     .command("measure", { isDefault: true })
     .description("Measure coverage for changed files")
-    .option("-b, --base <branch>", "Base branch to diff against", "main")
+    .option(
+      "-b, --base <branch>",
+      "Base branch for diff (default: merge-base of HEAD and main)",
+    )
     .option("-c, --cwd <path>", "Project root directory", process.cwd())
     .option(
       "-r, --runner <runner>",

--- a/src/presentations/cli/commands/review-schema.ts
+++ b/src/presentations/cli/commands/review-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { RunnerEnumSchema } from "../../../applications/shared/runner-enum.js";
 
 export const ReviewCLIOptsSchema = z.object({
-  base: z.string().default("main"),
+  base: z.string().optional(),
   cmd: z.string().optional(),
   cwd: z.string(),
   dryRun: z.boolean().optional(),

--- a/src/presentations/cli/commands/review.ts
+++ b/src/presentations/cli/commands/review.ts
@@ -34,7 +34,9 @@ const handleReviewError = (err: unknown): never => {
 
 const runReviewCommand = async (opts: ReviewCliOptions): Promise<void> => {
   try {
-    console.error(`📝 Reviewing PR for current branch (base: ${opts.base})...`);
+    console.error(
+      `📝 Reviewing PR for current branch (base: ${opts.base ?? "merge-base of HEAD and main"})...`,
+    );
     const outcome = await runReview({
       base: opts.base,
       cwd: resolve(opts.cwd),
@@ -68,7 +70,10 @@ export const registerReviewCommand = (program: Command): void => {
     .description(
       "Post inline review comments on the GitHub PR for the current branch (uses `gh` CLI for auth)",
     )
-    .option("-b, --base <branch>", "Base branch to diff against", "main")
+    .option(
+      "-b, --base <branch>",
+      "Base branch for diff (default: merge-base of HEAD and main)",
+    )
     .option("-c, --cwd <path>", "Project root directory", process.cwd())
     .option(
       "-r, --runner <runner>",

--- a/src/presentations/cli/commands/typecheck-schema.ts
+++ b/src/presentations/cli/commands/typecheck-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const TypecheckCLIOptsSchema = z.object({
-  base: z.string().default("main"),
+  base: z.string().optional(),
   cmd: z.string().optional(),
   cwd: z.string(),
   ext: z.string().default("ts,tsx,mts,cts"),

--- a/src/presentations/cli/commands/typecheck.ts
+++ b/src/presentations/cli/commands/typecheck.ts
@@ -15,7 +15,9 @@ const runTypecheckCommand = async (
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
 
-  console.error(`🔍 Type-checking diff against ${opts.base}...`);
+  console.error(
+    `🔍 Type-checking diff against ${opts.base ?? "merge-base of HEAD and main"}...`,
+  );
 
   try {
     const diffFiles = await getDiffFiles(cwd, opts.base, extensions);
@@ -60,7 +62,10 @@ export const registerTypecheckCommand = (program: Command): void => {
   program
     .command("typecheck")
     .description("Run TypeScript type-check on changed files")
-    .option("-b, --base <branch>", "Base branch to diff against", "main")
+    .option(
+      "-b, --base <branch>",
+      "Base branch for diff (default: merge-base of HEAD and main)",
+    )
     .option("-c, --cwd <path>", "Project root directory", process.cwd())
     .option(
       "--cmd <command>",

--- a/src/presentations/mcp/tools/diff.ts
+++ b/src/presentations/mcp/tools/diff.ts
@@ -14,8 +14,9 @@ export const registerDiffTool = (server: McpServer): void => {
       base: z
         .string()
         .optional()
-        .default("main")
-        .describe("Base branch to diff against"),
+        .describe(
+          "Base branch to diff against (default: merge-base of HEAD and main)",
+        ),
       cwd: z.string().describe("Absolute path to the project root"),
       exclude: z
         .array(z.string())

--- a/src/presentations/mcp/tools/measure.ts
+++ b/src/presentations/mcp/tools/measure.ts
@@ -19,8 +19,9 @@ export const registerMeasureTool = (server: McpServer): void => {
       base: z
         .string()
         .optional()
-        .default("main")
-        .describe("Base branch/ref to diff against (default: main)"),
+        .describe(
+          "Base branch/ref to diff against (default: merge-base of HEAD and main)",
+        ),
       cwd: z
         .string()
         .describe(

--- a/src/presentations/mcp/tools/review.ts
+++ b/src/presentations/mcp/tools/review.ts
@@ -21,8 +21,9 @@ export const registerReviewTool = (server: McpServer): void => {
       base: z
         .string()
         .optional()
-        .default("main")
-        .describe("Base branch/ref to diff against (default: main)"),
+        .describe(
+          "Base branch/ref to diff against (default: merge-base of HEAD and main)",
+        ),
       cwd: z.string().describe("Absolute path to the project root"),
       dryRun: z
         .boolean()

--- a/src/repositories/git.test.ts
+++ b/src/repositories/git.test.ts
@@ -5,7 +5,12 @@ vi.mock("execa", () => ({
 }));
 
 import { execa } from "execa";
-import { getCurrentBranch, getDiffFiles, getRemoteOriginUrl } from "./git.js";
+import {
+  getCurrentBranch,
+  getDiffFiles,
+  getMergeBase,
+  getRemoteOriginUrl,
+} from "./git.js";
 
 const mockExeca = vi.mocked(execa);
 
@@ -219,6 +224,43 @@ describe("getDiffFiles", () => {
     expect(files[1].path).toBe("src/b.ts");
     expect(files[1].additions).toBe(2);
     expect(files[1].deletions).toBe(1);
+  });
+
+  it("calls git merge-base when base is omitted and uses the hash as baseRef", async () => {
+    mockGit(
+      { stdout: "abc1234\n" },
+      { stdout: "/project" },
+      { stdout: "src/foo.ts" },
+      { stdout: "1\t0\tsrc/foo.ts" },
+      { stdout: "" },
+    );
+
+    const files = await getDiffFiles("/project");
+
+    expect(files).toHaveLength(1);
+    const mergeBaseCall = mockExeca.mock.calls[0];
+    expect(mergeBaseCall[1]).toEqual(["merge-base", "HEAD", "main"]);
+    const nameOnlyCall = mockExeca.mock.calls[2];
+    expect(nameOnlyCall[1]).toContain("abc1234");
+  });
+});
+
+describe("getMergeBase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the trimmed merge-base commit hash", async () => {
+    mockExeca.mockResolvedValueOnce({ stdout: "deadbeef1234\n" } as never);
+    const hash = await getMergeBase("/project");
+    expect(hash).toBe("deadbeef1234");
+    expect(mockExeca).toHaveBeenCalledWith(
+      "git",
+      ["merge-base", "HEAD", "main"],
+      {
+        cwd: "/project",
+      },
+    );
   });
 });
 

--- a/src/repositories/git.ts
+++ b/src/repositories/git.ts
@@ -29,6 +29,13 @@ const resolveBaseRef = async (cwd: string, base: string): Promise<string> => {
   }
 };
 
+export const getMergeBase = async (cwd: string): Promise<string> => {
+  const { stdout } = await execa("git", ["merge-base", "HEAD", "main"], {
+    cwd,
+  });
+  return stdout.trim();
+};
+
 const getAddedLines = async (
   cwd: string,
   base: string,
@@ -65,7 +72,7 @@ const getAddedLines = async (
 
 export const getDiffFiles = async (
   cwd: string,
-  base = "main",
+  base?: string,
   extensions = DEFAULT_EXTENSIONS,
   excludePatterns = DEFAULT_EXCLUDE,
   extraExcludePatterns: string[] = [],
@@ -73,7 +80,10 @@ export const getDiffFiles = async (
   const extPattern = extensions.join("|");
   const allExcludePatterns = [...excludePatterns, ...extraExcludePatterns];
 
-  const baseRef = await resolveBaseRef(cwd, base);
+  const baseRef =
+    base !== undefined
+      ? await resolveBaseRef(cwd, base)
+      : await getMergeBase(cwd);
 
   const { stdout: gitRoot } = await execa(
     "git",


### PR DESCRIPTION
When --base is omitted, getDiffFiles now runs `git merge-base HEAD main`
and uses the resulting commit hash as the diff base instead of hardcoding
"main". This gives a more accurate branch diff by comparing against the
point where the branch diverged, not the current tip of main.

https://claude.ai/code/session_01N4AHT4unXVaXivErdDPhhX