### PR TITLE
feat: auto-detect monorepo packages from diff files

### DIFF
--- a/src/applications/measure/format.ts
+++ b/src/applications/measure/format.ts
@@ -1,5 +1,11 @@
 import type { DiffCoverageResult } from "./coverage.js";
 
+type PackageResult = {
+  cwd: string;
+  outcome: { coverage: DiffCoverageResult };
+  relCwd: string;
+};
+
 const getCoverageIcon = (pct: number): string => {
   if (pct >= 80) return "✅";
   if (pct >= 50) return "⚠️";
@@ -58,3 +64,13 @@ export const formatResult = (
 
   return out.join("\n");
 };
+
+export const formatMonorepoResult = (
+  packages: PackageResult[],
+  threshold?: number,
+): string =>
+  packages
+    .map(
+      (p) => `📦 ${p.relCwd}\n${formatResult(p.outcome.coverage, threshold)}`,
+    )
+    .join("\n\n---\n\n");

--- a/src/applications/measure/index.ts
+++ b/src/applications/measure/index.ts
@@ -1,11 +1,13 @@
+import { relative } from "node:path";
 import { loadConfig } from "../../repositories/config-file.js";
 import type { DiffFile } from "../../repositories/git.js";
 import { getDiffFiles } from "../../repositories/git.js";
+import { remapDiffFilePaths } from "../../repositories/monorepo.js";
 import { globToRegex } from "../shared/glob.js";
 import type { DiffCoverageResult, RunOptions } from "./coverage.js";
 import { runCoverage } from "./runner-orchestrator.js";
 
-type MeasureOptions = {
+export type MeasureOptions = {
   base?: string;
   cwd: string;
   exclude?: string[];
@@ -75,4 +77,32 @@ export const runMeasure = async (
 ): Promise<MeasureOutcome> => {
   const diffFiles = await resolveMeasureDiffFiles(opts);
   return measureWithDiffFiles(opts, diffFiles);
+};
+
+export type MonorepoMeasureOutcome = {
+  packages: Array<{
+    cwd: string;
+    outcome: MeasureOutcome;
+    relCwd: string;
+  }>;
+};
+
+export const measureMonorepo = async (
+  opts: MeasureOptions,
+  packageMap: Map<string, DiffFile[]>,
+): Promise<MonorepoMeasureOutcome> => {
+  const packages: MonorepoMeasureOutcome["packages"] = [];
+  for (const [pkgCwd, pkgFiles] of packageMap) {
+    const remapped = remapDiffFilePaths(pkgFiles, opts.cwd, pkgCwd);
+    const outcome = await measureWithDiffFiles(
+      { ...opts, cwd: pkgCwd },
+      remapped,
+    );
+    packages.push({
+      cwd: pkgCwd,
+      outcome,
+      relCwd: relative(opts.cwd, pkgCwd) || ".",
+    });
+  }
+  return { packages };
 };

--- a/src/presentations/cli/commands/measure.ts
+++ b/src/presentations/cli/commands/measure.ts
@@ -1,74 +1,137 @@
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import type { Command } from "commander";
 import type { z } from "zod";
 import { resolveRunner } from "../../../applications/detect/index.js";
 import { formatDiffFiles } from "../../../applications/diff/index.js";
-import { formatResult } from "../../../applications/measure/format.js";
 import {
+  formatMonorepoResult,
+  formatResult,
+} from "../../../applications/measure/format.js";
+import {
+  type MeasureOptions,
+  type MeasureOutcome,
+  type MonorepoMeasureOutcome,
+  measureMonorepo,
   measureWithDiffFiles,
   resolveMeasureDiffFiles,
 } from "../../../applications/measure/index.js";
+import type { DiffFile } from "../../../repositories/git.js";
+import { groupDiffFilesByPackage } from "../../../repositories/monorepo.js";
 import { parseCsv, parseCsvOption } from "../csv.js";
 import { MeasureCLIOptsSchema } from "./measure-schema.js";
 
 type MeasureCliOptions = z.infer<typeof MeasureCLIOptsSchema>;
 
+const printMonorepoResult = (
+  outcome: MonorepoMeasureOutcome,
+  threshold: number | undefined,
+  json: boolean | undefined,
+): void => {
+  if (json) {
+    console.log(
+      JSON.stringify(
+        outcome.packages.map((p) => ({
+          coverage: p.outcome.coverage,
+          cwd: p.relCwd,
+        })),
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(formatMonorepoResult(outcome.packages, threshold));
+  }
+  if (outcome.packages.some((p) => p.outcome.thresholdMet === false)) {
+    process.exit(1);
+  }
+};
+
+const printSingleResult = (
+  outcome: MeasureOutcome,
+  threshold: number | undefined,
+  json: boolean | undefined,
+): void => {
+  if (json) {
+    console.log(JSON.stringify(outcome.coverage, null, 2));
+  } else {
+    console.log(formatResult(outcome.coverage, threshold));
+  }
+  if (outcome.thresholdMet === false) {
+    process.exit(1);
+  }
+};
+
+const runMonorepoMode = async (
+  opts: MeasureCliOptions,
+  baseOpts: MeasureOptions,
+  packageMap: Map<string, DiffFile[]>,
+): Promise<void> => {
+  console.error(
+    `📊 Measuring diff coverage against ${opts.base ?? "merge-base of HEAD and main"} (monorepo: ${packageMap.size} packages)...`,
+  );
+  console.error(
+    [...packageMap.entries()]
+      .map(
+        ([pkgCwd, pkgFiles]) =>
+          `📁 ${relative(baseOpts.cwd, pkgCwd) || "."}: ${pkgFiles.map((f) => f.path).join(", ")}`,
+      )
+      .join("\n"),
+  );
+  const outcome = await measureMonorepo(baseOpts, packageMap);
+  printMonorepoResult(outcome, opts.threshold, opts.json);
+};
+
+const runSinglePackageMode = async (
+  opts: MeasureCliOptions,
+  baseOpts: MeasureOptions,
+  diffFiles: DiffFile[],
+): Promise<void> => {
+  const runner = await resolveRunner(baseOpts.cwd, opts.runner);
+  console.error(
+    `📊 Measuring diff coverage against ${opts.base ?? "merge-base of HEAD and main"} (runner: ${runner})...`,
+  );
+  console.error(`📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`);
+  console.error(`🧪 Running ${runner === "vitest" ? "Vitest" : "Jest"}...\n`);
+  const outcome = await measureWithDiffFiles(
+    { ...baseOpts, runner },
+    diffFiles,
+  );
+  printSingleResult(outcome, opts.threshold, opts.json);
+};
+
 const runMeasureCommand = async (opts: MeasureCliOptions): Promise<void> => {
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
   const exclude = parseCsvOption(opts.exclude);
-  const runner = await resolveRunner(cwd, opts.runner);
-
-  console.error(
-    `📊 Measuring diff coverage against ${opts.base ?? "merge-base of HEAD and main"} (runner: ${runner})...`,
-  );
+  const baseOpts: MeasureOptions = {
+    base: opts.base,
+    cwd,
+    exclude,
+    extensions,
+    runner: opts.runner,
+    testCommand: opts.cmd,
+    threshold: opts.threshold,
+  };
 
   try {
-    const diffFiles = await resolveMeasureDiffFiles({
-      base: opts.base,
-      cwd,
-      exclude,
-      extensions,
-    });
+    const diffFiles = await resolveMeasureDiffFiles(baseOpts);
 
     if (diffFiles.length === 0) {
       console.log("No changed source files found.");
       process.exit(0);
     }
 
-    console.error(
-      `📁 Changed files: ${diffFiles.map((f) => f.path).join(", ")}`,
-    );
-
     if (opts.diffOnly) {
       console.log(formatDiffFiles(diffFiles));
       process.exit(0);
     }
 
-    const runnerLabel = runner === "vitest" ? "Vitest" : "Jest";
-    console.error(`🧪 Running ${runnerLabel}...\n`);
+    const packageMap = await groupDiffFilesByPackage(cwd, diffFiles);
 
-    const outcome = await measureWithDiffFiles(
-      {
-        base: opts.base,
-        cwd,
-        exclude,
-        extensions,
-        runner,
-        testCommand: opts.cmd,
-        threshold: opts.threshold,
-      },
-      diffFiles,
-    );
-
-    if (opts.json) {
-      console.log(JSON.stringify(outcome.coverage, null, 2));
+    if (packageMap.size > 1) {
+      await runMonorepoMode(opts, baseOpts, packageMap);
     } else {
-      console.log(formatResult(outcome.coverage, opts.threshold));
-    }
-
-    if (outcome.thresholdMet === false) {
-      process.exit(1);
+      await runSinglePackageMode(opts, baseOpts, diffFiles);
     }
   } catch (err) {
     console.error("Error:", err instanceof Error ? err.message : err);

--- a/src/presentations/mcp/tools/measure.ts
+++ b/src/presentations/mcp/tools/measure.ts
@@ -1,9 +1,17 @@
 import { resolve } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { formatResult } from "../../../applications/measure/format.js";
-import { runMeasure } from "../../../applications/measure/index.js";
+import {
+  formatMonorepoResult,
+  formatResult,
+} from "../../../applications/measure/format.js";
+import {
+  measureMonorepo,
+  measureWithDiffFiles,
+  resolveMeasureDiffFiles,
+} from "../../../applications/measure/index.js";
 import { RunnerEnumSchema } from "../../../applications/shared/runner-enum.js";
+import { groupDiffFilesByPackage } from "../../../repositories/monorepo.js";
 
 const RunnerSchema = RunnerEnumSchema.optional()
   .default("auto")
@@ -61,17 +69,20 @@ export const registerMeasureTool = (server: McpServer): void => {
       threshold,
     }) => {
       try {
-        const outcome = await runMeasure({
+        const resolvedCwd = resolve(cwd);
+        const opts = {
           base,
-          cwd: resolve(cwd),
+          cwd: resolvedCwd,
           exclude,
           extensions,
           runner,
           testCommand,
           threshold,
-        });
+        };
 
-        if (outcome.diffFiles.length === 0) {
+        const diffFiles = await resolveMeasureDiffFiles(opts);
+
+        if (diffFiles.length === 0) {
           return {
             content: [
               {
@@ -82,6 +93,39 @@ export const registerMeasureTool = (server: McpServer): void => {
           };
         }
 
+        const packageMap = await groupDiffFilesByPackage(
+          resolvedCwd,
+          diffFiles,
+        );
+
+        if (packageMap.size > 1) {
+          const monorepoOutcome = await measureMonorepo(opts, packageMap);
+          const isError = monorepoOutcome.packages.some(
+            (p) => p.outcome.thresholdMet === false,
+          );
+          return {
+            content: [
+              {
+                text: formatMonorepoResult(monorepoOutcome.packages, threshold),
+                type: "text",
+              },
+              {
+                text: JSON.stringify(
+                  monorepoOutcome.packages.map((p) => ({
+                    coverage: p.outcome.coverage,
+                    cwd: p.relCwd,
+                  })),
+                  null,
+                  2,
+                ),
+                type: "text",
+              },
+            ],
+            isError,
+          };
+        }
+
+        const outcome = await measureWithDiffFiles(opts, diffFiles);
         return {
           content: [
             { text: formatResult(outcome.coverage, threshold), type: "text" },

--- a/src/repositories/monorepo.test.ts
+++ b/src/repositories/monorepo.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn(),
+}));
+
+import { access } from "node:fs/promises";
+import type { DiffFile } from "./git.js";
+import {
+  findNearestPackageDir,
+  groupDiffFilesByPackage,
+  remapDiffFilePaths,
+} from "./monorepo.js";
+
+const mockAccess = vi.mocked(access);
+
+const diffFile = (overrides: Partial<DiffFile> = {}): DiffFile => ({
+  addedLines: [],
+  additions: 0,
+  deletions: 0,
+  path: "src/foo.ts",
+  repoPath: "src/foo.ts",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("findNearestPackageDir", () => {
+  it("returns startDir when package.json is found there", async () => {
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    const result = await findNearestPackageDir("/repo/src", "/repo");
+
+    expect(result).toBe("/repo/src");
+    expect(mockAccess).toHaveBeenCalledWith("/repo/src/package.json");
+  });
+
+  it("walks up to find package.json when not in startDir", async () => {
+    mockAccess
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await findNearestPackageDir("/repo/src", "/repo");
+
+    expect(result).toBe("/repo");
+  });
+
+  it("returns null when no package.json found within stopDir", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await findNearestPackageDir("/repo/src", "/repo");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null immediately when startDir is outside stopDir", async () => {
+    const result = await findNearestPackageDir("/other/src", "/repo");
+
+    expect(result).toBeNull();
+    expect(mockAccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("groupDiffFilesByPackage", () => {
+  it("groups all files under one entry when they share the same nearest package.json", async () => {
+    mockAccess.mockImplementation(async (path) => {
+      if (String(path) === "/repo/package.json") return;
+      throw new Error("ENOENT");
+    });
+
+    const files = [
+      diffFile({ path: "src/a.ts", repoPath: "src/a.ts" }),
+      diffFile({ path: "src/b.ts", repoPath: "src/b.ts" }),
+    ];
+
+    const result = await groupDiffFilesByPackage("/repo", files);
+
+    expect(result.size).toBe(1);
+    expect(result.get("/repo")).toEqual(files);
+  });
+
+  it("splits files into separate entries when they have different nearest package.json", async () => {
+    mockAccess.mockImplementation(async (path) => {
+      const p = String(path);
+      if (
+        p === "/repo/packages/a/package.json" ||
+        p === "/repo/packages/b/package.json"
+      ) {
+        return;
+      }
+      throw new Error("ENOENT");
+    });
+
+    const fileA = diffFile({
+      path: "packages/a/src/a.ts",
+      repoPath: "packages/a/src/a.ts",
+    });
+    const fileB = diffFile({
+      path: "packages/b/src/b.ts",
+      repoPath: "packages/b/src/b.ts",
+    });
+
+    const result = await groupDiffFilesByPackage("/repo", [fileA, fileB]);
+
+    expect(result.size).toBe(2);
+    expect(result.get("/repo/packages/a")).toEqual([fileA]);
+    expect(result.get("/repo/packages/b")).toEqual([fileB]);
+  });
+
+  it("falls back to cwd when no package.json is found", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const files = [
+      diffFile({ path: "src/a.ts", repoPath: "src/a.ts" }),
+      diffFile({ path: "src/b.ts", repoPath: "src/b.ts" }),
+    ];
+
+    const result = await groupDiffFilesByPackage("/repo", files);
+
+    expect(result.size).toBe(1);
+    expect(result.get("/repo")).toEqual(files);
+  });
+});
+
+describe("remapDiffFilePaths", () => {
+  it.each([
+    {
+      expectedPath: "src/foo.ts",
+      name: "remaps path one level down",
+      newCwd: "/repo/packages/a",
+      originalCwd: "/repo",
+      path: "packages/a/src/foo.ts",
+      repoPath: "packages/a/src/foo.ts",
+    },
+    {
+      expectedPath: "lib/utils/bar.ts",
+      name: "remaps path with deeper nesting",
+      newCwd: "/repo/packages/b",
+      originalCwd: "/repo",
+      path: "packages/b/lib/utils/bar.ts",
+      repoPath: "packages/b/lib/utils/bar.ts",
+    },
+  ])("$name", ({ path, repoPath, originalCwd, newCwd, expectedPath }) => {
+    const file = diffFile({ path, repoPath });
+    const [result] = remapDiffFilePaths([file], originalCwd, newCwd);
+
+    expect(result?.path).toBe(expectedPath);
+  });
+
+  it("leaves repoPath unchanged", () => {
+    const file = diffFile({
+      path: "packages/a/src/foo.ts",
+      repoPath: "packages/a/src/foo.ts",
+    });
+
+    const [result] = remapDiffFilePaths([file], "/repo", "/repo/packages/a");
+
+    expect(result?.repoPath).toBe("packages/a/src/foo.ts");
+  });
+});

--- a/src/repositories/monorepo.ts
+++ b/src/repositories/monorepo.ts
@@ -1,0 +1,50 @@
+import { access } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import type { DiffFile } from "./git.js";
+
+export const findNearestPackageDir = async (
+  startDir: string,
+  stopDir: string,
+): Promise<string | null> => {
+  let dir = startDir;
+  while (dir === stopDir || dir.startsWith(`${stopDir}/`)) {
+    try {
+      await access(join(dir, "package.json"));
+      return dir;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return null;
+};
+
+export const groupDiffFilesByPackage = async (
+  cwd: string,
+  diffFiles: DiffFile[],
+): Promise<Map<string, DiffFile[]>> => {
+  const entries = await Promise.all(
+    diffFiles.map(async (file) => {
+      const absPath = resolve(cwd, file.path);
+      const pkgDir = await findNearestPackageDir(dirname(absPath), cwd);
+      return { file, pkgDir: pkgDir ?? cwd };
+    }),
+  );
+
+  return entries.reduce<Map<string, DiffFile[]>>((acc, { file, pkgDir }) => {
+    const existing = acc.get(pkgDir) ?? [];
+    acc.set(pkgDir, [...existing, file]);
+    return acc;
+  }, new Map());
+};
+
+export const remapDiffFilePaths = (
+  files: DiffFile[],
+  originalCwd: string,
+  newCwd: string,
+): DiffFile[] =>
+  files.map((file) => ({
+    ...file,
+    path: relative(newCwd, resolve(originalCwd, file.path)),
+  }));


### PR DESCRIPTION
## 背景

`diff-coverage` は現在 `--cwd` を単一パッケージルートに指定する必要があります。モノレポ環境で git diff が複数パッケージにまたがる場合、リポジトリルートから実行するとランナー検出やカバレッジ計測が正しく動作しません。

Issue #33 では `--monorepo` フラグの追加が提案されていましたが、オーナーのコメントで「フラグなしで cwd の位置を基準に自動処理したい」との修正が入りました。`cwd` が単一パッケージを指す場合は従来通り、diff ファイルが複数の `package.json` 境界にまたがる場合は自動的にパッケージごとに分割して計測します。

Closes #33

## 変更内容

- `src/repositories/monorepo.ts` を新規追加: `findNearestPackageDir`（最寄りの package.json を検索）、`groupDiffFilesByPackage`（DiffFile をパッケージルートでグループ化）、`remapDiffFilePaths`（新 cwd 相対にパスを変換）の 3 関数
- `src/repositories/monorepo.test.ts` を新規追加: `node:fs/promises` access をモックした全関数のユニットテスト
- `src/applications/measure/index.ts`: `MeasureOptions` を export 化、`MonorepoMeasureOutcome` 型と `measureMonorepo` 関数を追加（テストランナーのポート競合を避けるため逐次実行）
- `src/applications/measure/format.ts`: `formatMonorepoResult` を追加（📦 ヘッダ付きで各パッケージの `formatResult` を結合）
- `src/presentations/cli/commands/measure.ts`: diff ファイル解決後に `groupDiffFilesByPackage` を呼び出し、2 件以上のパッケージが検出された場合は自動でモノレポモードへ切り替え。Biome の複雑度制限（max 10）に合わせてヘルパー関数に分割
- `src/presentations/mcp/tools/measure.ts`: 同様の自動検出ロジックを追加

## 動作確認

- [x] CI が pass していること（typecheck / test 232件 / biome check / knip / coverage 93.4%）