### PR TITLE
fix: テストランナーのエラーをCLI出力に伝播させる

### DIFF
--- a/src/applications/measure/runner-orchestrator.test.ts
+++ b/src/applications/measure/runner-orchestrator.test.ts
@@ -75,7 +75,8 @@ describe("runCoverage", () => {
   });
 
   it("calls detectRunner with cwd when runner option is auto", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage({ cwd: CWD, runner: "auto" }, [
       makeDiffFile("src/foo.ts"),
     ]);
@@ -83,7 +84,8 @@ describe("runCoverage", () => {
   });
 
   it("infers vitest from testCommand without calling detectRunner", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage(
       {
         cwd: CWD,
@@ -97,7 +99,8 @@ describe("runCoverage", () => {
   });
 
   it("infers jest from testCommand without calling detectRunner", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage(
       { cwd: CWD, testCommand: "pnpm exec jest --config jest.config.ts" },
       [makeDiffFile("src/foo.ts")],
@@ -108,7 +111,8 @@ describe("runCoverage", () => {
   });
 
   it("falls back to detectRunner when testCommand has no known runner keyword", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage({ cwd: CWD, testCommand: "pnpm test" }, [
       makeDiffFile("src/foo.ts"),
     ]);
@@ -116,7 +120,8 @@ describe("runCoverage", () => {
   });
 
   it("invokes jest runner when runner is jest", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage({ cwd: CWD, runner: "jest" }, [
       makeDiffFile("src/foo.ts"),
     ]);
@@ -125,7 +130,8 @@ describe("runCoverage", () => {
   });
 
   it("invokes vitest runner when runner is vitest", async () => {
-    mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
+    mockReadCoverageSummary.mockResolvedValueOnce({});
+    mockReadCoverageFinal.mockResolvedValueOnce({});
     await runCoverage({ cwd: CWD, runner: "vitest" }, [
       makeDiffFile("src/foo.ts"),
     ]);
@@ -133,12 +139,11 @@ describe("runCoverage", () => {
     expect(mockRunJest).not.toHaveBeenCalled();
   });
 
-  it("returns empty result when coverage-summary.json is missing", async () => {
+  it("throws when coverage-summary.json is missing", async () => {
     mockReadCoverageSummary.mockRejectedValueOnce(new Error("ENOENT"));
-    const result = await runCoverage({ cwd: CWD, runner: "jest" }, [
-      makeDiffFile("src/foo.ts"),
-    ]);
-    expect(result.files).toEqual([]);
+    await expect(
+      runCoverage({ cwd: CWD, runner: "jest" }, [makeDiffFile("src/foo.ts")]),
+    ).rejects.toThrow("Failed to read coverage report");
   });
 
   it("still returns coverage data when coverage-final.json is missing", async () => {

--- a/src/applications/measure/runner-orchestrator.ts
+++ b/src/applications/measure/runner-orchestrator.ts
@@ -50,7 +50,9 @@ export const runCoverage = async (
   try {
     summaryData = await readCoverageSummary(cwd);
   } catch {
-    return emptyResult(runner);
+    throw new Error(
+      "Failed to read coverage report. The test runner may have exited with an error — check the output above.",
+    );
   }
 
   try {

--- a/src/repositories/runners/jest.ts
+++ b/src/repositories/runners/jest.ts
@@ -25,5 +25,7 @@ export const runJest = async (
     cwd,
     env: { ...process.env, CI: "true" },
     reject: false,
+    stderr: "inherit",
+    stdout: "inherit",
   });
 };

--- a/src/repositories/runners/vitest.ts
+++ b/src/repositories/runners/vitest.ts
@@ -98,6 +98,8 @@ export async function runVitest(
       cwd,
       env: { ...process.env, CI: "true" },
       reject: false,
+      stderr: "inherit",
+      stdout: "inherit",
     });
   });
 


### PR DESCRIPTION
# 背景

Jest/Vitest がエラーで失敗してカバレッジレポートが生成されなかった場合、エラーが握り潰されてユーザーに何も表示されない問題があった。原因は2つ：

1. execa の `reject: false` でランナーの stdout/stderr がパイプされて捨てられる
2. `runner-orchestrator.ts` がカバレッジ読み込み失敗時に `emptyResult` を無言で返していた

presentations 層の catch ブロックは正しく実装されていたが、例外が伝播してこないため機能していなかった。

# 変更内容

- `jest.ts` / `vitest.ts`: execa に `stdout: "inherit"`, `stderr: "inherit"` を追加し、ランナーの出力をリアルタイムでターミナルに表示するように変更
- `runner-orchestrator.ts`: `readCoverageSummary` 失敗時のサイレントな `emptyResult` 返却を、上位層へのエラースローに変更
- `runner-orchestrator.test.ts`: カバレッジ読み込み失敗テストを `rejects.toThrow` に更新、ランナー選択テストのモックを `mockResolvedValueOnce({})` に変更

# 動作確認

- [x] CIが pass していること