### PR TITLE
feat: measure コマンドに --output オプションを追加して PR レビュー投稿に対応

### DIFF
--- a/src/applications/shared/output-enum.ts
+++ b/src/applications/shared/output-enum.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const OutputEnumSchema = z.enum(["stdout", "pr-review"]);

--- a/src/presentations/measure/index.ts
+++ b/src/presentations/measure/index.ts
@@ -14,17 +14,13 @@ import {
   measureWithDiffFiles,
   resolveMeasureDiffFiles,
 } from "../../applications/measure/index.js";
-import {
-  formatReviewResult,
-  runReview,
-} from "../../applications/review/index.js";
 import type { DiffFile } from "../../repositories/git.js";
 import {
   groupDiffFilesByPackage,
   remapDiffFilePaths,
 } from "../../repositories/monorepo.js";
 import { parseCsv, parseCsvOption } from "../shared/csv.js";
-import { handleReviewError } from "../shared/handle-review-error.js";
+import { runReviewOutput } from "../shared/run-review-output.js";
 import { MeasureCLIOptsSchema, type MeasureCliOptions } from "./schema.js";
 
 const printMonorepoResult = (
@@ -125,33 +121,9 @@ const resolveSinglePackageArgs = (
   return { pkgFiles: diffFiles, pkgOpts: baseOpts };
 };
 
-const runPrReviewMode = async (opts: MeasureCliOptions): Promise<void> => {
-  try {
-    console.error(
-      `📝 Reviewing PR for current branch (base: ${opts.base ?? "merge-base of HEAD and main"})...`,
-    );
-    const outcome = await runReview({
-      base: opts.base,
-      cwd: resolve(opts.cwd),
-      dryRun: opts.dryRun,
-      exclude: parseCsvOption(opts.exclude),
-      extensions: parseCsv(opts.ext),
-      include: parseCsvOption(opts.include),
-      pr: opts.pr,
-      runner: opts.runner,
-      testCommand: opts.cmd,
-      threshold: opts.threshold,
-    });
-    console.log(formatReviewResult(outcome));
-    if (outcome.thresholdMet === false) process.exit(1);
-  } catch (err) {
-    handleReviewError(err);
-  }
-};
-
 const runMeasureCommand = async (opts: MeasureCliOptions): Promise<void> => {
   if (opts.output === "pr-review") {
-    await runPrReviewMode(opts);
+    await runReviewOutput(opts);
     return;
   }
 

--- a/src/presentations/measure/index.ts
+++ b/src/presentations/measure/index.ts
@@ -14,12 +14,17 @@ import {
   measureWithDiffFiles,
   resolveMeasureDiffFiles,
 } from "../../applications/measure/index.js";
+import {
+  formatReviewResult,
+  runReview,
+} from "../../applications/review/index.js";
 import type { DiffFile } from "../../repositories/git.js";
 import {
   groupDiffFilesByPackage,
   remapDiffFilePaths,
 } from "../../repositories/monorepo.js";
 import { parseCsv, parseCsvOption } from "../shared/csv.js";
+import { handleReviewError } from "../shared/handle-review-error.js";
 import { MeasureCLIOptsSchema, type MeasureCliOptions } from "./schema.js";
 
 const printMonorepoResult = (
@@ -120,7 +125,36 @@ const resolveSinglePackageArgs = (
   return { pkgFiles: diffFiles, pkgOpts: baseOpts };
 };
 
+const runPrReviewMode = async (opts: MeasureCliOptions): Promise<void> => {
+  try {
+    console.error(
+      `📝 Reviewing PR for current branch (base: ${opts.base ?? "merge-base of HEAD and main"})...`,
+    );
+    const outcome = await runReview({
+      base: opts.base,
+      cwd: resolve(opts.cwd),
+      dryRun: opts.dryRun,
+      exclude: parseCsvOption(opts.exclude),
+      extensions: parseCsv(opts.ext),
+      include: parseCsvOption(opts.include),
+      pr: opts.pr,
+      runner: opts.runner,
+      testCommand: opts.cmd,
+      threshold: opts.threshold,
+    });
+    console.log(formatReviewResult(outcome));
+    if (outcome.thresholdMet === false) process.exit(1);
+  } catch (err) {
+    handleReviewError(err);
+  }
+};
+
 const runMeasureCommand = async (opts: MeasureCliOptions): Promise<void> => {
+  if (opts.output === "pr-review") {
+    await runPrReviewMode(opts);
+    return;
+  }
+
   const cwd = resolve(opts.cwd);
   const extensions = parseCsv(opts.ext);
   const exclude = parseCsvOption(opts.exclude);
@@ -193,8 +227,25 @@ export const registerMeasureCommand = (program: Command): void => {
       "Fail if line coverage is below this %",
       Number.parseFloat,
     )
-    .option("--json", "Output raw JSON")
-    .option("--diff-only", "Only show diff files, don't run tests")
+    .option(
+      "--output <mode>",
+      "Output mode: stdout | pr-review (default: stdout)",
+      "stdout",
+    )
+    .option("--json", "Output raw JSON (only with --output stdout)")
+    .option(
+      "--diff-only",
+      "Only show diff files, don't run tests (only with --output stdout)",
+    )
+    .option(
+      "--pr <number>",
+      "PR number override (only with --output pr-review)",
+      (v) => Number.parseInt(v, 10),
+    )
+    .option(
+      "--dry-run",
+      "Print planned PR comments without posting (only with --output pr-review)",
+    )
     .option(
       "--exclude <patterns>",
       "Comma-separated glob patterns to exclude files (e.g. '*.mocks.ts,src/fixtures/**')",

--- a/src/presentations/measure/schema.test.ts
+++ b/src/presentations/measure/schema.test.ts
@@ -10,4 +10,50 @@ describe("MeasureCLIOptsSchema", () => {
 
     expect(parsed.include).toBe("src/**,packages/api/**");
   });
+
+  it("defaults output to stdout", () => {
+    const parsed = MeasureCLIOptsSchema.parse({ cwd: "/repo" });
+    expect(parsed.output).toBe("stdout");
+  });
+
+  it.each([
+    {
+      input: { cwd: "/repo", json: true, output: "pr-review" },
+      name: "--json with --output pr-review",
+      path: "json",
+    },
+    {
+      input: { cwd: "/repo", diffOnly: true, output: "pr-review" },
+      name: "--diff-only with --output pr-review",
+      path: "diffOnly",
+    },
+    {
+      input: { cwd: "/repo", output: "stdout", pr: 42 },
+      name: "--pr with --output stdout",
+      path: "pr",
+    },
+    {
+      input: { cwd: "/repo", dryRun: true, output: "stdout" },
+      name: "--dry-run with --output stdout",
+      path: "dryRun",
+    },
+  ])("rejects $name", ({ input, path }) => {
+    const result = MeasureCLIOptsSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes(path))).toBe(true);
+    }
+  });
+
+  it("accepts --pr and --dry-run with --output pr-review", () => {
+    const parsed = MeasureCLIOptsSchema.parse({
+      cwd: "/repo",
+      dryRun: true,
+      output: "pr-review",
+      pr: 42,
+    });
+    expect(parsed.output).toBe("pr-review");
+    expect(parsed.pr).toBe(42);
+    expect(parsed.dryRun).toBe(true);
+  });
 });

--- a/src/presentations/measure/schema.ts
+++ b/src/presentations/measure/schema.ts
@@ -1,17 +1,56 @@
 import { z } from "zod";
+import { OutputEnumSchema } from "../../applications/shared/output-enum.js";
 import { RunnerEnumSchema } from "../../applications/shared/runner-enum.js";
 
-export const MeasureCLIOptsSchema = z.object({
-  base: z.string().optional(),
-  cmd: z.string().optional(),
-  cwd: z.string(),
-  diffOnly: z.boolean().optional(),
-  exclude: z.string().optional(),
-  ext: z.string().default("ts,tsx,js,jsx"),
-  include: z.string().optional(),
-  json: z.boolean().optional(),
-  runner: RunnerEnumSchema.default("auto"),
-  threshold: z.number().optional(),
-});
+export const MeasureCLIOptsSchema = z
+  .object({
+    base: z.string().optional(),
+    cmd: z.string().optional(),
+    cwd: z.string(),
+    diffOnly: z.boolean().optional(),
+    dryRun: z.boolean().optional(),
+    exclude: z.string().optional(),
+    ext: z.string().default("ts,tsx,js,jsx"),
+    include: z.string().optional(),
+    json: z.boolean().optional(),
+    output: OutputEnumSchema.default("stdout"),
+    pr: z.number().int().positive().optional(),
+    runner: RunnerEnumSchema.default("auto"),
+    threshold: z.number().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.output === "stdout") {
+      if (data.pr !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "--pr requires --output pr-review",
+          path: ["pr"],
+        });
+      }
+      if (data.dryRun) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "--dry-run requires --output pr-review",
+          path: ["dryRun"],
+        });
+      }
+    }
+    if (data.output === "pr-review") {
+      if (data.json) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "--json is not compatible with --output pr-review",
+          path: ["json"],
+        });
+      }
+      if (data.diffOnly) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "--diff-only is not compatible with --output pr-review",
+          path: ["diffOnly"],
+        });
+      }
+    }
+  });
 
 export type MeasureCliOptions = z.infer<typeof MeasureCLIOptsSchema>;

--- a/src/presentations/review/index.ts
+++ b/src/presentations/review/index.ts
@@ -2,34 +2,16 @@ import { resolve } from "node:path";
 import type { Command } from "commander";
 import {
   formatReviewResult,
-  NoPullRequestError,
   runReview,
 } from "../../applications/review/index.js";
-import {
-  GhNotAuthenticatedError,
-  GhNotInstalledError,
-} from "../../repositories/github.js";
 import { parseCsv, parseCsvOption } from "../shared/csv.js";
+import { handleReviewError } from "../shared/handle-review-error.js";
 import { ReviewCLIOptsSchema, type ReviewCliOptions } from "./schema.js";
 
-const handleReviewError = (err: unknown): never => {
-  if (err instanceof GhNotInstalledError) {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
-  }
-  if (err instanceof GhNotAuthenticatedError) {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
-  }
-  if (err instanceof NoPullRequestError) {
-    console.error(`Error: ${err.message}`);
-    process.exit(2);
-  }
-  console.error("Error:", err instanceof Error ? err.message : err);
-  process.exit(1);
-};
-
 const runReviewCommand = async (opts: ReviewCliOptions): Promise<void> => {
+  console.error(
+    "⚠️  `review` is deprecated and will be removed in a future release. Use `measure --output pr-review` instead.",
+  );
   try {
     console.error(
       `📝 Reviewing PR for current branch (base: ${opts.base ?? "merge-base of HEAD and main"})...`,

--- a/src/presentations/shared/handle-review-error.test.ts
+++ b/src/presentations/shared/handle-review-error.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../applications/review/index.js", () => ({
+  NoPullRequestError: class NoPullRequestError extends Error {
+    code = "NO_PR" as const;
+    constructor(branch: string) {
+      super(`No open pull request found for branch "${branch}".`);
+      this.name = "NoPullRequestError";
+    }
+  },
+}));
+vi.mock("../../repositories/github.js", () => ({
+  GhNotAuthenticatedError: class GhNotAuthenticatedError extends Error {
+    constructor() {
+      super("gh is not authenticated");
+      this.name = "GhNotAuthenticatedError";
+    }
+  },
+  GhNotInstalledError: class GhNotInstalledError extends Error {
+    constructor() {
+      super("gh is not installed");
+      this.name = "GhNotInstalledError";
+    }
+  },
+}));
+
+import { NoPullRequestError } from "../../applications/review/index.js";
+import {
+  GhNotAuthenticatedError,
+  GhNotInstalledError,
+} from "../../repositories/github.js";
+import { handleReviewError } from "./handle-review-error.js";
+
+describe("handleReviewError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it.each([
+    {
+      error: () => new GhNotInstalledError(),
+      expectedCode: 1,
+      name: "GhNotInstalledError",
+    },
+    {
+      error: () => new GhNotAuthenticatedError(),
+      expectedCode: 1,
+      name: "GhNotAuthenticatedError",
+    },
+    {
+      error: () => new NoPullRequestError("feat/my-branch"),
+      expectedCode: 2,
+      name: "NoPullRequestError",
+    },
+    {
+      error: () => new Error("unexpected failure"),
+      expectedCode: 1,
+      name: "unknown Error",
+    },
+  ])("calls process.exit($expectedCode) for $name", ({
+    error,
+    expectedCode,
+  }) => {
+    expect(() => handleReviewError(error())).toThrow("process.exit called");
+    expect(process.exit).toHaveBeenCalledWith(expectedCode);
+  });
+});

--- a/src/presentations/shared/handle-review-error.ts
+++ b/src/presentations/shared/handle-review-error.ts
@@ -1,0 +1,22 @@
+import { NoPullRequestError } from "../../applications/review/index.js";
+import {
+  GhNotAuthenticatedError,
+  GhNotInstalledError,
+} from "../../repositories/github.js";
+
+export const handleReviewError = (err: unknown): never => {
+  if (err instanceof GhNotInstalledError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+  if (err instanceof GhNotAuthenticatedError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+  if (err instanceof NoPullRequestError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(2);
+  }
+  console.error("Error:", err instanceof Error ? err.message : err);
+  process.exit(1);
+};

--- a/src/presentations/shared/run-review-output.test.ts
+++ b/src/presentations/shared/run-review-output.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../applications/review/index.js", () => ({
+  formatReviewResult: vi.fn().mockReturnValue("=== review result ==="),
+  NoPullRequestError: class NoPullRequestError extends Error {
+    code = "NO_PR" as const;
+    constructor(branch: string) {
+      super(`No open pull request found for branch "${branch}".`);
+      this.name = "NoPullRequestError";
+    }
+  },
+  runReview: vi.fn(),
+}));
+vi.mock("../../repositories/github.js", () => ({
+  GhNotAuthenticatedError: class GhNotAuthenticatedError extends Error {
+    constructor() {
+      super("gh is not authenticated");
+      this.name = "GhNotAuthenticatedError";
+    }
+  },
+  GhNotInstalledError: class GhNotInstalledError extends Error {
+    constructor() {
+      super("gh is not installed");
+      this.name = "GhNotInstalledError";
+    }
+  },
+}));
+
+import {
+  formatReviewResult,
+  runReview,
+} from "../../applications/review/index.js";
+import { runReviewOutput } from "./run-review-output.js";
+
+const mockRunReview = vi.mocked(runReview);
+const mockFormatReviewResult = vi.mocked(formatReviewResult);
+
+const makeOutcome = (thresholdMet: boolean | null = null) => ({
+  coverage: {} as never,
+  dryRun: false,
+  planned: [],
+  posted: [],
+  pr: { headSha: "abc", number: 1, url: "https://example.com/pr/1" },
+  skippedExisting: 0,
+  thresholdMet,
+  updatedExisting: 0,
+});
+
+const baseArgs = {
+  cwd: "/repo",
+  ext: "ts,tsx",
+  runner: "auto" as const,
+};
+
+describe("runReviewOutput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("calls runReview and logs formatted result", async () => {
+    mockRunReview.mockResolvedValue(makeOutcome(true));
+
+    await runReviewOutput(baseArgs);
+
+    expect(mockRunReview).toHaveBeenCalledOnce();
+    expect(mockFormatReviewResult).toHaveBeenCalledOnce();
+    expect(console.log).toHaveBeenCalledWith("=== review result ===");
+  });
+
+  it("passes base to console.error progress message", async () => {
+    mockRunReview.mockResolvedValue(makeOutcome());
+
+    await runReviewOutput({ ...baseArgs, base: "develop" });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("develop"),
+    );
+  });
+
+  it("exits with 1 when thresholdMet is false", async () => {
+    mockRunReview.mockResolvedValue(makeOutcome(false));
+
+    await expect(runReviewOutput(baseArgs)).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit when thresholdMet is null", async () => {
+    mockRunReview.mockResolvedValue(makeOutcome(null));
+
+    await runReviewOutput(baseArgs);
+
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it("calls handleReviewError on runReview failure", async () => {
+    mockRunReview.mockRejectedValue(new Error("network error"));
+
+    await expect(runReviewOutput(baseArgs)).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/presentations/shared/run-review-output.ts
+++ b/src/presentations/shared/run-review-output.ts
@@ -7,7 +7,7 @@ import {
 import { parseCsv, parseCsvOption } from "./csv.js";
 import { handleReviewError } from "./handle-review-error.js";
 
-export type ReviewOutputArgs = {
+type ReviewOutputArgs = {
   base?: string;
   cmd?: string;
   cwd: string;

--- a/src/presentations/shared/run-review-output.ts
+++ b/src/presentations/shared/run-review-output.ts
@@ -1,0 +1,47 @@
+import { resolve } from "node:path";
+import type { RunOptions } from "../../applications/measure/coverage.js";
+import {
+  formatReviewResult,
+  runReview,
+} from "../../applications/review/index.js";
+import { parseCsv, parseCsvOption } from "./csv.js";
+import { handleReviewError } from "./handle-review-error.js";
+
+export type ReviewOutputArgs = {
+  base?: string;
+  cmd?: string;
+  cwd: string;
+  dryRun?: boolean;
+  exclude?: string;
+  ext: string;
+  include?: string;
+  pr?: number;
+  runner: RunOptions["runner"];
+  threshold?: number;
+};
+
+export const runReviewOutput = async (
+  opts: ReviewOutputArgs,
+): Promise<void> => {
+  try {
+    console.error(
+      `📝 Reviewing PR for current branch (base: ${opts.base ?? "merge-base of HEAD and main"})...`,
+    );
+    const outcome = await runReview({
+      base: opts.base,
+      cwd: resolve(opts.cwd),
+      dryRun: opts.dryRun,
+      exclude: parseCsvOption(opts.exclude),
+      extensions: parseCsv(opts.ext),
+      include: parseCsvOption(opts.include),
+      pr: opts.pr,
+      runner: opts.runner,
+      testCommand: opts.cmd,
+      threshold: opts.threshold,
+    });
+    console.log(formatReviewResult(outcome));
+    if (outcome.thresholdMet === false) process.exit(1);
+  } catch (err) {
+    handleReviewError(err);
+  }
+};


### PR DESCRIPTION
## 背景

現状 `measure` コマンドは stdout (テキスト / `--json`) にしか出力できず、GitHub PR にインラインレビューコメントを投稿したい場合は別サブコマンド `review` を呼ぶ必要があった。両コマンドは内部で同じ測定パイプラインを走らせており、`runReview` 内の `runMeasurement` が `runMeasureCommand` のロジックを再実装するという重複も存在していた。これを解消し、1 つのコマンドで出力先を切り替えられるようにする。

## 変更内容

- `measure` コマンドに `--output stdout|pr-review` オプションを追加 (デフォルト: `stdout`)
- `--output pr-review` 時は既存の `review` サブコマンドと同等の PR インラインレビューを投稿
- PR 固有の `--pr <number>` / `--dry-run` オプションを `measure` にも露出
- `--json` / `--diff-only` と `--output pr-review` の不正な組み合わせを Zod の `.superRefine` でバリデーション
- `handleReviewError` を `src/presentations/shared/handle-review-error.ts` に切り出して `measure` / `review` で共有
- `review` サブコマンドを非推奨化 — 実行時に deprecation 警告を表示 (機能は維持)
- `src/applications/shared/output-enum.ts` を `runner-enum.ts` と同パターンで新規追加
- スキーマテストに output バリデーションのケースを追加

## 動作確認

- [x] `pnpm test` (229 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm check` (Biome)
- [x] pre-push フック (coverage / knip / typecheck) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)